### PR TITLE
feat: Implement command-line result input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,81 @@ their respective terminals.
 
 ## Getting Started
 
-To run the app, please ensure that [.NET 9.0](https://dotnet.microsoft.com/download) is installed on your machine.
+To run the app, please ensure that [.NET 9.0 SDK](https://dotnet.microsoft.com/download) is installed.
+
+### Project Structure
+The project is structured as follows:
+
+```
+rankings/
+├── .github/
+│   ├── ISSUE_TEMPLATE/          # GitHub issue templates
+│   ├── workflows/               # GitHub Actions workflows
+├── src/
+│   ├── Rankings/                # Main application source code
+├── test/
+│   ├── Rankings.UnitTests/      # Unit tests for the application
+├── .gitignore                   # Git ignore file
+├── CODE_OF_CONDUCT.md           # Code of conduct
+├── CONTRIBUTING.md              # Contribution guidelines
+├── LICENSE                      # License file
+├── Rankings.sln                 # Solution file
+├── README.md                    # This readme file
+├── SECRET.md                    # Security policy
+```
+
+## Developing
+
+### AI Usage
+
+This project has been developed with the assistance of artificial intelligence (AI) tools, per the following:
+- **GitHub Copilot:** Used to assist with code generation and suggestions within the IDE, commit messages, pull request
+  descriptions, pull request reviews, and documentation.
+- **Grok:** Used to assist with research and code review using the [Tom Prompt](https://github.com/SebGSX/Prompt-Engineering/blob/main/prompt-engineering/pull-request-review.md).
+
+### Code Quality and Security
+
+Code quality is supported using a variety of tools, including:
+- **SonarQube Cloud:** Used to perform static code analysis and provide code quality and security reports.
+- **GitHub Security Tools:** See the [Security Tab](https://github.com/SebGSX/rankings/security) within the repo. 
+  Please note that CodeQL and Dependabot are enabled as is the secret scanning feature. Pull request reviews are
+  handled by the author and supported by GitHub Copilot. Branch protection rules require pull requests for merges to
+  the `main` branch, require checks to pass, and automatically request a review from GitHub Copilot.
+- **ReSharper:** Used to perform static code analysis and provide code quality suggestions within the IDE.
+- **Unit Tests:** The project is covered by unit tests using xUnit and Moq. Code coverage is reported to SonarQube
+  Cloud.
+
+### Building
+
+Provided that the .NET 9.0 SDK is installed, the project can be built from within an appropriate IDE such as Rider,
+VS Code, or Visual Studio, or from the command line at the project's root directory using:
+
+```shell
+dotnet build
+```
+
+### Running
+
+The project can be run from within an appropriate IDE or from the command line at `src/Rankings/bin/Debug/net9.0/`
+using the following command for Linux or macOS:
+
+```bash
+./rankings
+```
+
+Or the following command for Windows:
+
+```shell
+.\rankings
+```
+
+### Testing
+
+The unit tests can be run from within an appropriate IDE or from the command line at the project's root directory using:
+
+```shell
+dotnet test
+```
 
 ## Contributing
 

--- a/src/Rankings/CommandLineOptions.cs
+++ b/src/Rankings/CommandLineOptions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+namespace Rankings;
+
+/// <summary>
+///     Represents the sets of command line options including their aliases.
+/// </summary>
+public abstract record CommandLineOptions
+{
+    /// <summary>
+    ///     Represents the result option and its aliases.
+    /// </summary>
+    /// <remarks>The first element is the primary name, and the rest are aliases.</remarks>
+    public static string[] ResultOption
+    {
+        get;
+    } = ["--result", "-r"];
+}

--- a/src/Rankings/Extensions/RankingsRootCommandExtensions.cs
+++ b/src/Rankings/Extensions/RankingsRootCommandExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+using System.CommandLine;
+using Rankings.Parsers;
+using Rankings.Resources;
+using Rankings.Validators;
+
+namespace Rankings.Extensions;
+
+/// <summary>
+///     Extensions for the <see cref="RootCommand" /> class.
+/// </summary>
+public static class RankingsRootCommandExtensions
+{
+    /// <summary>
+    ///     Adds the result option to the root command.
+    /// </summary>
+    /// <param name="rootCommand">The root command receiving the option.</param>
+    /// <returns>The root command with the option added.</returns>
+    public static RootCommand AddResultOption(this RootCommand rootCommand)
+    {
+        var resultOption = new Option<string>(
+            name: CommandLineOptions.ResultOption[0],
+            aliases: CommandLineOptions.ResultOption[1..])
+        {
+            Description = string.Format(Common.ResultOption_Description, ResultParser.ContestantResultSeparator),
+            Validators = { ResultValidator.Validate() }
+        };
+        
+        rootCommand.Options.Add(resultOption);
+        
+        return rootCommand;
+    }
+}

--- a/src/Rankings/Parsers/ResultParser.cs
+++ b/src/Rankings/Parsers/ResultParser.cs
@@ -1,0 +1,230 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+using System.Diagnostics;
+using Rankings.Resources;
+
+namespace Rankings.Parsers;
+
+/// <summary>
+///     Represents the contestant result parser.
+/// </summary>
+/// <remarks>Operates on a single line of input only.</remarks>
+public class ResultParser
+{
+    /// <summary>
+    ///     The character that separates individual contestant results in an input string.
+    /// </summary>
+    public const string ContestantResultSeparator = ",";
+    
+    /// <summary>
+    ///     The character that separates a contestant's name from their score in an input string.
+    /// </summary>
+    private const string ContestantScoreSeparator = " ";
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ResultParser" /> class with the specified input string.
+    /// </summary>
+    /// <param name="input">The input to parse for contestant results.</param>
+    public ResultParser(string input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        // Check for new line characters in the input first to avoid ambiguity with whitespace check.
+        if (input.Contains('\n', StringComparison.InvariantCultureIgnoreCase)
+            || input.Contains('\r', StringComparison.InvariantCultureIgnoreCase))
+        {
+            throw new ArgumentException(Common.CannotContainNewLine, nameof(input));
+        }
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            throw new ArgumentException(Common.EmptyOrWhiteSpace, nameof(input));
+        }
+        var inputTrimmed = input.Trim();
+        
+        /*
+         * Validate the input and store the result flags.
+         *
+         * Since string operations are generally costly and a results file may contain many entries, performing the
+         * validation once during initialization and storing the result flags is more efficient than multiple checks
+         * for the same condition for each contestant result. While seemingly small, the cumulative performance impact
+         * over a large input dataset can be significant depending on how the flags are used later in the processing.
+         */
+        const int notFound = -1;
+        var firstIndex = inputTrimmed.IndexOf(ContestantResultSeparator, StringComparison.InvariantCultureIgnoreCase);
+        var lastIndex = inputTrimmed.LastIndexOf(ContestantResultSeparator, StringComparison.InvariantCultureIgnoreCase);
+        
+        #region Validate Basic Structure
+        HasMultipleContestantResultSeparators = firstIndex != lastIndex;
+        IsMissingContestantResultSeparator = firstIndex == notFound;
+
+        if (HasMultipleContestantResultSeparators
+            || IsMissingContestantResultSeparator)
+        {
+            /*
+             * If the input is invalid, set default values for contestant names and scores as well as the associated
+             * flags.
+             */
+            Contestant1Name = string.Empty;
+            Contestant1Score = 0;
+            Contestant2Name = string.Empty;
+            Contestant2Score = 0;
+            
+            HasNoContestant1Name = true;
+            HasNoContestant1Result = true;
+            HasNoContestant1Score = true;
+            HasNoContestant2Name = true;
+            HasNoContestant2Result = true;
+            HasNoContestant2Score = true;
+            return;
+        }
+        #endregion
+        
+        var contestantResults = inputTrimmed.Split(ContestantResultSeparator);
+        // There should always be exactly two results after splitting by the separator.
+        Debug.Assert(contestantResults.Length == 2);
+        var contestant1ResultString = contestantResults[0].Trim();
+        var contestant2ResultString = contestantResults[1].Trim();
+
+        var contestant1Result = ParseContestantResult(contestant1ResultString);
+        var contestant2Result = ParseContestantResult(contestant2ResultString);
+
+        #region Validate Parsed Results
+        HasNoContestant1Result = firstIndex == 0; // Separator is at the start.
+        HasNoContestant2Result = lastIndex == inputTrimmed.Length - 1; // Separator is at the end.
+
+        HasNoContestant1Name = string.IsNullOrWhiteSpace(contestant1Result.Name);
+        HasNoContestant1Score = contestant1Result.Score < 0;
+        HasNoContestant2Name = string.IsNullOrWhiteSpace(contestant2Result.Name);
+        HasNoContestant2Score = contestant2Result.Score < 0;
+        
+        Contestant1Name = contestant1Result.Name;
+        Contestant1Score = contestant1Result.Score > 0 ? (ushort)contestant1Result.Score : (ushort)0;
+        Contestant2Name = contestant2Result.Name;
+        Contestant2Score = contestant2Result.Score > 0 ? (ushort)contestant2Result.Score : (ushort)0;
+        #endregion
+    }
+    
+    /// <summary>
+    ///     Gets the first contestant's name, if any.
+    /// </summary>
+    /// <remarks>
+    ///     If the name is missing, this property returns an empty string.
+    /// </remarks>
+    public string Contestant1Name { get; }
+    
+    /// <summary>
+    ///     Gets the first contestant's score, if any.
+    /// </summary>
+    /// <remarks>
+    ///     If the score is missing or invalid, this property returns <c>0</c>.
+    /// </remarks>
+    public ushort Contestant1Score { get; }
+    
+    /// <summary>
+    ///     Gets the second contestant's name, if any.
+    /// </summary>
+    /// <remarks>
+    ///     If the name is missing, this property returns an empty string.
+    /// </remarks>
+    public string Contestant2Name { get; }
+    
+    /// <summary>
+    ///     Gets the second contestant's score, if any.
+    /// </summary>
+    /// <remarks>
+    ///     If the score is missing or invalid, this property returns <c>0</c>.
+    /// </remarks>
+    public ushort Contestant2Score { get; }
+
+    /// <summary>
+    ///     Indicates whether the input has multiple contestant result separators.
+    /// </summary>
+    /// <returns>
+    ///     <c>True</c> if the input has multiple contestant result separators; otherwise, <c>false</c>.
+    /// </returns>
+    public bool HasMultipleContestantResultSeparators { get; }
+    
+    /// <summary>
+    ///     Indicates whether the input is missing the first contestant's name.
+    /// </summary>
+    /// <returns>
+    ///     <c>True</c> if the input has no first contestant name; otherwise, <c>false</c>.
+    /// </returns>
+    public bool HasNoContestant1Name { get; }
+
+    /// <summary>
+    ///     Indicates whether the input is missing the first contestant result.
+    /// </summary>
+    /// <returns>
+    ///     <c>True</c> if the input has no first contestant result separators; otherwise, <c>false</c>.
+    /// </returns>
+    public bool HasNoContestant1Result { get; }
+
+    /// <summary>
+    ///     Indicates whether the input is missing the first contestant's score.
+    /// </summary>
+    /// <returns>
+    ///     <c>True</c> if the input has no first contestant score; otherwise, <c>false</c>.
+    /// </returns>
+    public bool HasNoContestant1Score { get; }
+
+    /// <summary>
+    ///     Indicates whether the input is missing the second contestant's name.
+    /// </summary>
+    /// <returns>
+    ///     <c>True</c> if the input has no second contestant name; otherwise, <c>false</c>.
+    /// </returns>
+    public bool HasNoContestant2Name { get; }
+    
+    /// <summary>
+    ///     Indicates whether the input is missing the second contestant result.
+    /// </summary>
+    /// <returns>
+    ///     <c>True</c> if the input has no second contestant result separators; otherwise, <c>false</c>.
+    /// </returns>
+    public bool HasNoContestant2Result { get; }
+    
+    /// <summary>
+    ///     Indicates whether the input is missing the second contestant's score.
+    /// </summary>
+    /// <returns>
+    ///     <c>True</c> if the input has no second contestant score; otherwise, <c>false</c>.
+    /// </returns>
+    public bool HasNoContestant2Score { get; }
+
+    /// <summary>
+    ///     Indicates whether the input is missing the contestant result separator.
+    /// </summary>
+    /// <returns>
+    ///     <c>True</c> if the input is missing the contestant result separator; otherwise, <c>false</c>.
+    /// </returns>
+    public bool IsMissingContestantResultSeparator { get; }
+
+    /// <summary>
+    ///     Parses a contestant result string into a name and score.
+    /// </summary>
+    /// <param name="contestantResult">The contestant result string to parse.</param>
+    /// <returns>
+    ///     A tuple containing the contestant's name and score. If the name is missing, an empty string is returned. If
+    ///     the score is missing or invalid, <c>-1</c> is returned.
+    /// </returns>
+    private static (string Name, short Score) ParseContestantResult(string contestantResult)
+    {
+        const short notFound = -1;
+        var contestantLastSpaceIndex = contestantResult
+            .LastIndexOf(ContestantScoreSeparator, StringComparison.InvariantCultureIgnoreCase);
+        
+        // If there's no space, either the name or score is missing.
+        if (contestantLastSpaceIndex == notFound)
+        {
+            return short.TryParse(contestantResult, out var parsedOnlyScore)
+                ? (string.Empty, parsedOnlyScore) // Only the score is present.
+                : (contestantResult, notFound); // Only the name is present.
+        }
+
+        // Try to parse the score from the remainder of the text; if it fails, return noScore.
+        return short.TryParse(contestantResult[(contestantLastSpaceIndex + 1)..].Trim(), out var score)
+            ? (contestantResult[..contestantLastSpaceIndex].Trim(), score) // Successfully parsed both name and score.
+            : (contestantResult, notFound); // Name is present, but score parsing failed.
+    }
+}

--- a/src/Rankings/Program.cs
+++ b/src/Rankings/Program.cs
@@ -2,6 +2,7 @@
 // Published under the MIT License.
 
 using System.CommandLine;
+using Rankings.Extensions;
 using Rankings.Resources;
 
 namespace Rankings;
@@ -12,12 +13,24 @@ namespace Rankings;
 public abstract class Program
 {
     /// <summary>
+    ///     Represents the root command of the application.
+    /// </summary>
+    private static readonly RootCommand RootCommand = new(Common.RootCommand_Description);
+    
+    /// <summary>
     ///     The main entry point for the application.
     /// </summary>
     /// <param name="args">The command-line arguments.</param>
     public static void Main(string[] args)
     {
-        var rootCommand = new RootCommand(Common.RootCommand_Description);
-        rootCommand.Parse(args).Invoke();
+        RootCommand.AddResultOption();
+        
+        // Automatically handles unhandled exceptions thrown during parsing or invocation.
+        RootCommand.Parse(args).Invoke();
     }
+    
+    /// <summary>
+    ///     Gets the configured options for the application.
+    /// </summary>
+    public static IList<Option> ConfiguredOptions => RootCommand.Options;
 }

--- a/src/Rankings/Resources/Common.Designer.cs
+++ b/src/Rankings/Resources/Common.Designer.cs
@@ -60,6 +60,87 @@ namespace Rankings.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Value cannot contain a new line..
+        /// </summary>
+        internal static string CannotContainNewLine {
+            get {
+                return ResourceManager.GetString("CannotContainNewLine", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value cannot be empty or white-space..
+        /// </summary>
+        internal static string EmptyOrWhiteSpace {
+            get {
+                return ResourceManager.GetString("EmptyOrWhiteSpace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Adds a single contest result to the results file. A result must be in the form: &quot;&lt;CONTESTANT-1&gt; &lt;SCORE-1&gt;, &lt;CONTESTANT-2&gt; &lt;SCORE-2&gt;&quot;. Replace &lt;CONTESTANT-n&gt; with the contestants&apos; names such as, Team One, Team Two, etc. Names cannot start with - or --, and they cannot include the {0} symbol. Scores must be non-negative, whole numbers without any separator symbols, which means for example that 1000 is appropriate but 1,000 is not. Example: rankings -r &quot;My Team 1{0} Other Team 0&quot;.
+        /// </summary>
+        internal static string ResultOption_Description {
+            get {
+                return ResourceManager.GetString("ResultOption_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A result must be separated into two parts by the {0} symbol; one part for each contestant&apos;s name and score..
+        /// </summary>
+        internal static string ResultOption_Validation_MissingContestantResultSeparator {
+            get {
+                return ResourceManager.GetString("ResultOption_Validation_MissingContestantResultSeparator", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A result can only contain one {0} symbol..
+        /// </summary>
+        internal static string ResultOption_Validation_MultipleContestantResultSeparators {
+            get {
+                return ResourceManager.GetString("ResultOption_Validation_MultipleContestantResultSeparators", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A result must not contain any line breaks, it must be a single line..
+        /// </summary>
+        internal static string ResultOption_Validation_NewLineWithinContestantResult {
+            get {
+                return ResourceManager.GetString("ResultOption_Validation_NewLineWithinContestantResult", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A result must include names for both contestants. Cannot find a name for contestant {0}..
+        /// </summary>
+        internal static string ResultOption_Validation_NoContestantName {
+            get {
+                return ResourceManager.GetString("ResultOption_Validation_NoContestantName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A result must include the results for both contestants. Cannot find a result for contestant {0}..
+        /// </summary>
+        internal static string ResultOption_Validation_NoContestantResult {
+            get {
+                return ResourceManager.GetString("ResultOption_Validation_NoContestantResult", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A result must include scores for both contestants. Cannot find a score for contestant {0}..
+        /// </summary>
+        internal static string ResultOption_Validation_NoContestantScore {
+            get {
+                return ResourceManager.GetString("ResultOption_Validation_NoContestantScore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Generate a ranking table..
         /// </summary>
         internal static string RootCommand_Description {

--- a/src/Rankings/Resources/Common.resx
+++ b/src/Rankings/Resources/Common.resx
@@ -21,4 +21,31 @@
     <data name="RootCommand_Description" xml:space="preserve">
         <value>Generate a ranking table.</value>
     </data>
+    <data name="ResultOption_Description" xml:space="preserve">
+        <value>Adds a single contest result to the results file. A result must be in the form: "&lt;CONTESTANT-1&gt; &lt;SCORE-1&gt;, &lt;CONTESTANT-2&gt; &lt;SCORE-2&gt;". Replace &lt;CONTESTANT-n&gt; with the contestants' names such as, Team One, Team Two, etc. Names cannot start with - or --, and they cannot include the {0} symbol. Scores must be non-negative, whole numbers without any separator symbols, which means for example that 1000 is appropriate but 1,000 is not. Example: rankings -r "My Team 1{0} Other Team 0"</value>
+    </data>
+    <data name="ResultOption_Validation_MissingContestantResultSeparator" xml:space="preserve">
+        <value>A result must be separated into two parts by the {0} symbol; one part for each contestant's name and score.</value>
+    </data>
+    <data name="ResultOption_Validation_MultipleContestantResultSeparators" xml:space="preserve">
+        <value>A result can only contain one {0} symbol.</value>
+    </data>
+    <data name="EmptyOrWhiteSpace" xml:space="preserve">
+        <value>Value cannot be empty or white-space.</value>
+    </data>
+    <data name="CannotContainNewLine" xml:space="preserve">
+        <value>Value cannot contain a new line.</value>
+    </data>
+    <data name="ResultOption_Validation_NewLineWithinContestantResult" xml:space="preserve">
+        <value>A result must not contain any line breaks, it must be a single line.</value>
+    </data>
+    <data name="ResultOption_Validation_NoContestantResult" xml:space="preserve">
+        <value>A result must include the results for both contestants. Cannot find a result for contestant {0}.</value>
+    </data>
+    <data name="ResultOption_Validation_NoContestantName" xml:space="preserve">
+        <value>A result must include names for both contestants. Cannot find a name for contestant {0}.</value>
+    </data>
+    <data name="ResultOption_Validation_NoContestantScore" xml:space="preserve">
+        <value>A result must include scores for both contestants. Cannot find a score for contestant {0}.</value>
+    </data>
 </root>

--- a/src/Rankings/Validators/ResultValidator.cs
+++ b/src/Rankings/Validators/ResultValidator.cs
@@ -1,0 +1,70 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Diagnostics;
+using Rankings.Parsers;
+using Rankings.Resources;
+
+namespace Rankings.Validators;
+
+/// <summary>
+///     Validates the result option.
+/// </summary>
+public abstract class ResultValidator
+{
+    /// <summary>
+    ///     Ensures that the option result contains a valid contestant result.
+    /// </summary>
+    /// <returns>An action that validates the option result.</returns>
+    public static Action<OptionResult> Validate()
+    {
+        return result =>
+        {
+            try
+            {
+                // The result should never be null.
+                Debug.Assert(result != null);
+                Debug.Assert(result.GetValueOrDefault<string>() != null);
+                var resultParser = new ResultParser(result.GetValueOrDefault<string>());
+
+                // Identify validation errors in the order they should be reported.
+                var validations = new List<(bool IsError, string ErrorMessage)>
+                {
+                    (resultParser.HasMultipleContestantResultSeparators,
+                        string.Format(
+                            Common.ResultOption_Validation_MultipleContestantResultSeparators,
+                            ResultParser.ContestantResultSeparator)),
+                    (resultParser.IsMissingContestantResultSeparator,
+                        string.Format(
+                            Common.ResultOption_Validation_MissingContestantResultSeparator,
+                            ResultParser.ContestantResultSeparator)),
+                    (resultParser.HasNoContestant1Result,
+                        string.Format(Common.ResultOption_Validation_NoContestantResult, 1)),
+                    (resultParser.HasNoContestant2Result,
+                        string.Format(Common.ResultOption_Validation_NoContestantResult, 2)),
+                    (resultParser.HasNoContestant1Name,
+                        string.Format(Common.ResultOption_Validation_NoContestantName, 1)),
+                    (resultParser.HasNoContestant1Score,
+                        string.Format(Common.ResultOption_Validation_NoContestantScore, 1)),
+                    (resultParser.HasNoContestant2Name,
+                        string.Format(Common.ResultOption_Validation_NoContestantName, 2)),
+                    (resultParser.HasNoContestant2Score,
+                        string.Format(Common.ResultOption_Validation_NoContestantScore, 2))
+                };
+                
+                // Stop validation on the first error found, working from left to right.
+                foreach (var (isError, errorMessage) in validations)
+                {
+                    if (!isError) continue;
+                    result.AddError(errorMessage);
+                    return;
+                }
+            }
+            catch (ArgumentException)
+            {
+                result.AddError(Common.ResultOption_Validation_NewLineWithinContestantResult);
+            }
+        };
+    }
+}

--- a/test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs
+++ b/test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+using Rankings.Extensions;
+using System.CommandLine;
+using System.Diagnostics;
+
+namespace Rankings.UnitTests.Extensions;
+
+/// <summary>
+///     Unit tests for the <see cref="RankingsRootCommandExtensions" /> class.
+/// </summary>
+public class RankingsRootCommandExtensionsTests
+{
+    /// <summary>
+    ///     Tests that the <see cref="RankingsRootCommandExtensions.AddResultOption" /> method correctly adds the
+    ///     result option to a root command.
+    /// </summary>
+    [Fact]
+    public void AddResultOption_AddsOptionToRootCommand()
+    {
+        // Arrange
+        var rootCommand = new RootCommand();
+        const string expectedOptionName = "--result";
+        string[] expectedOptionAliases = ["-r"];
+        
+        // Act
+        rootCommand.AddResultOption();
+        var option = rootCommand.Options.FirstOrDefault(o => o.Name == expectedOptionName);
+        
+        // Assert
+        Assert.NotNull(option);
+        Assert.Equal(expectedOptionName, option.Name);
+        Assert.Equal(expectedOptionAliases, option.Aliases);
+        Assert.NotNull(option.Description);
+        Assert.NotEmpty(option.Description);
+    }
+}

--- a/test/Rankings.UnitTests/Parsers/ResultParserTests.cs
+++ b/test/Rankings.UnitTests/Parsers/ResultParserTests.cs
@@ -708,4 +708,60 @@ public class ResultParserTests
         Assert.Equal(expectedContestant2Name, parser.Contestant2Name);
         Assert.Equal(expectedContestant2Score, parser.Contestant2Score);
     }
+    
+    /// <summary>
+    ///     Tests that the constructor sets all properties correctly when the input is valid.
+    /// </summary>
+    /// <param name="input">The input to parse.</param>
+    /// <param name="expectedContestant1Name">The expected name of the first contestant.</param>
+    /// <param name="expectedContestant1Score">The expected score of the first contestant.</param>
+    /// <param name="expectedContestant2Name">The expected name of the second contestant.</param>
+    /// <param name="expectedContestant2Score">The expected score of the second contestant.</param>
+    [Theory]
+    [InlineData(
+        $"Alice 0{ResultParser.ContestantResultSeparator} Bob 0",
+        "Alice",
+        0,
+        "Bob",
+        0)]
+    [InlineData(
+        $"Alice in Wonderland 0{ResultParser.ContestantResultSeparator} Bob the Builder 0",
+        "Alice in Wonderland",
+        0,
+        "Bob the Builder",
+        0)]
+    [InlineData(
+        $"Awesome FC 22{ResultParser.ContestantResultSeparator} Boresome FC 11",
+        "Awesome FC",
+        22,
+        "Boresome FC",
+        11)]
+    public void Ctor_WithValidInput_SetsAllPropertiesCorrectly(
+        string input,
+        string expectedContestant1Name,
+        ushort expectedContestant1Score,
+        string expectedContestant2Name,
+        ushort expectedContestant2Score)
+    {
+        // Act
+        var parser = new ResultParser(input);
+        
+        // Assert
+        Assert.False(parser.HasMultipleContestantResultSeparators);
+        Assert.False(parser.IsMissingContestantResultSeparator);
+        
+        Assert.False(parser.HasNoContestant1Name);
+        Assert.False(parser.HasNoContestant1Result);
+        Assert.False(parser.HasNoContestant1Score);
+        
+        Assert.False(parser.HasNoContestant2Name);
+        Assert.False(parser.HasNoContestant2Result);
+        Assert.False(parser.HasNoContestant2Score);
+        
+        Assert.Equal(expectedContestant1Name, parser.Contestant1Name);
+        Assert.Equal(expectedContestant1Score, parser.Contestant1Score);
+        
+        Assert.Equal(expectedContestant2Name, parser.Contestant2Name);
+        Assert.Equal(expectedContestant2Score, parser.Contestant2Score);
+    }
 }

--- a/test/Rankings.UnitTests/Parsers/ResultParserTests.cs
+++ b/test/Rankings.UnitTests/Parsers/ResultParserTests.cs
@@ -1,0 +1,711 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+using Rankings.Parsers;
+
+namespace Rankings.UnitTests.Parsers;
+
+/// <summary>
+///     Unit tests for the <see cref="ResultParser" /> class.
+/// </summary>
+public class ResultParserTests
+{
+    /// <summary>
+    ///     Tests that the constructor throws an <see cref="ArgumentException" /> when the input is empty.
+    /// </summary>
+    /// <param name="input">The input to parse.</param>
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("  ")]
+    [InlineData("\t")]
+    [InlineData("\t ")]
+    [InlineData(" \t")]
+    [InlineData(" \t ")]
+    public void Ctor_WithEmptyInput_ThrowsArgumentException(string input)
+    {
+        // Act
+        var exception = Record.Exception(() => new ResultParser(input));
+        
+        // Assert
+        Assert.NotNull(exception);
+        Assert.IsType<ArgumentException>(exception);
+        Assert.Equal("input", ((ArgumentException)exception).ParamName);
+        Assert.Equal("Value cannot be empty or white-space. (Parameter 'input')", exception.Message);
+    }
+
+    /// <summary>
+    ///     Tests that the constructor sets all flags correctly when the input is invalid in multiple ways.
+    /// </summary>
+    /// <param name="input">The input to parse.</param>
+    /// <param name="expectedContestant1Name">The expected name of the first contestant.</param>
+    /// <param name="expectedContestant1Score">The expected score of the first contestant.</param>
+    /// <param name="expectedContestant2Name">The expected name of the second contestant.</param>
+    /// <param name="expectedContestant2Score">The expected score of the second contestant.</param>
+    /// <remarks>
+    ///     This test checks combinations that are not covered by the other tests.
+    /// </remarks>
+    [Theory]
+    [InlineData(
+        $"{ResultParser.ContestantResultSeparator}",
+        "",
+        0,
+        "",
+        0)]
+    [InlineData(
+        $"10{ResultParser.ContestantResultSeparator}",
+        "",
+        10,
+        "",
+        0)]
+    [InlineData(
+        $"{ResultParser.ContestantResultSeparator}10",
+        "",
+        0,
+        "",
+        10)]
+    [InlineData(
+        $"10{ResultParser.ContestantResultSeparator}10",
+        "",
+        10,
+        "",
+        10)]
+    [InlineData(
+        $"Alice in Wonderland{ResultParser.ContestantResultSeparator}",
+        "Alice in Wonderland",
+        0,
+        "",
+        0)]
+    [InlineData(
+        $"{ResultParser.ContestantResultSeparator}Bob the Builder",
+        "",
+        0,
+        "Bob the Builder",
+        0)]
+    [InlineData(
+        $"Alice in Wonderland{ResultParser.ContestantResultSeparator}Bob the Builder",
+        "Alice in Wonderland",
+        0,
+        "Bob the Builder",
+        0)]
+    [InlineData(
+        $"Alice in Wonderland{ResultParser.ContestantResultSeparator}10",
+        "Alice in Wonderland",
+        0,
+        "",
+        10)]
+    [InlineData(
+        $"10{ResultParser.ContestantResultSeparator}Bob the Builder",
+        "",
+        10,
+        "Bob the Builder",
+        0)]
+    [InlineData(
+        $"-1{ResultParser.ContestantResultSeparator}",
+        "",
+        0,
+        "",
+        0)]
+    [InlineData(
+        $"{ResultParser.ContestantResultSeparator}-1",
+        "",
+        0,
+        "",
+        0)]
+    [InlineData(
+        $"Alice in Wonderland-1{ResultParser.ContestantResultSeparator}",
+        "Alice in Wonderland-1",
+        0,
+        "",
+        0)]
+    [InlineData(
+        $"{ResultParser.ContestantResultSeparator}Bob the Builder-1",
+        "",
+        0,
+        "Bob the Builder-1",
+        0)]
+    [InlineData(
+        $"-1Alice in Wonderland{ResultParser.ContestantResultSeparator}",
+        "-1Alice in Wonderland",
+        0,
+        "",
+        0)]
+    [InlineData(
+        $"{ResultParser.ContestantResultSeparator}-1Bob the Builder",
+        "",
+        0,
+        "-1Bob the Builder",
+        0)]
+    public void Ctor_WithSingleContestantResultSeparatorAndInvalidInput_SetsFlagsAndPropertiesCorrectly(
+        string input,
+        string expectedContestant1Name,
+        ushort expectedContestant1Score,
+        string expectedContestant2Name,
+        ushort expectedContestant2Score)
+    {
+        // Arrange
+        var contestantResults = input.Split(ResultParser.ContestantResultSeparator);
+        var hasNoContestant1ResultExpected = string.IsNullOrWhiteSpace(contestantResults[0]);
+        var hasNoContestant2ResultExpected = string.IsNullOrWhiteSpace(contestantResults[1]);
+
+        // Act
+        var parser = new ResultParser(input);
+
+        // Assert
+        Assert.False(parser.HasMultipleContestantResultSeparators);
+        Assert.False(parser.IsMissingContestantResultSeparator);
+
+        Assert.Equal(string.IsNullOrWhiteSpace(expectedContestant1Name), parser.HasNoContestant1Name);
+        Assert.Equal(hasNoContestant1ResultExpected, parser.HasNoContestant1Result);
+        Assert.Equal(expectedContestant1Score == 0, parser.HasNoContestant1Score);
+
+        Assert.Equal(string.IsNullOrWhiteSpace(expectedContestant2Name), parser.HasNoContestant2Name);
+        Assert.Equal(hasNoContestant2ResultExpected, parser.HasNoContestant2Result);
+        Assert.Equal(expectedContestant2Score == 0, parser.HasNoContestant2Score);
+
+        Assert.Equal(expectedContestant1Name, parser.Contestant1Name);
+        Assert.Equal(expectedContestant1Score, parser.Contestant1Score);
+
+        Assert.Equal(expectedContestant2Name, parser.Contestant2Name);
+        Assert.Equal(expectedContestant2Score, parser.Contestant2Score);
+    }
+
+    /// <summary>
+    ///     Tests that the constructor throws an <see cref="ArgumentException" /> when the input contains a new line.
+    /// </summary>
+    /// <param name="input">The input to parse.</param>
+    [Theory]
+    [InlineData("Alice 1 \r Bob 2")]
+    [InlineData("Alice 1 \n Bob 2")]
+    [InlineData("Alice 1 \r\n Bob 2")]
+    [InlineData("Alice 1 \r\n\r\n Bob 2")]
+    [InlineData("Alice 1 \n\n Bob 2")]
+    [InlineData("Alice 1 \r\r Bob 2")]
+    [InlineData("\r")]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    [InlineData("\r\n\r\n")]
+    [InlineData("\n\n")]
+    [InlineData("\r\r")]
+    public void Ctor_WithNewLineInInput_ThrowsArgumentException(string input)
+    {
+        // Act
+        var exception = Record.Exception(() => new ResultParser(input));
+        
+        // Assert
+        Assert.NotNull(exception);
+        Assert.IsType<ArgumentException>(exception);
+        Assert.Equal("input", ((ArgumentException)exception).ParamName);
+        Assert.Equal("Value cannot contain a new line. (Parameter 'input')", exception.Message);
+    }
+    
+    /// <summary>
+    ///     Tests that the constructor throws an <see cref="ArgumentNullException" /> when the input is <c>null</c>.
+    /// </summary>
+    [Fact]
+    public void Ctor_WithNullInput_ThrowsArgumentNullException()
+    {
+        // Arrange
+        string input = null!;
+        
+        // Act
+        var exception = Record.Exception(() => new ResultParser(input));
+        
+        // Assert
+        Assert.NotNull(exception);
+        Assert.IsType<ArgumentNullException>(exception);
+        Assert.Equal("input", ((ArgumentNullException)exception).ParamName);
+    }
+    
+    /// <summary>
+    ///     Tests that the constructor sets <see cref="ResultParser.IsMissingContestantResultSeparator" />
+    ///     to <c>true</c> when the input is missing the contestant result separator, regardless of spacing.
+    /// </summary>
+    /// <param name="input"></param>
+    [Theory]
+    [InlineData("Alice 10 Bob 20")]
+    [InlineData("Alice 10  Bob 20")]
+    [InlineData("Alice 10\tBob 20")]
+    public void Ctor_WithMissingContestantResultSeparator_SetsIsMissingContestantResultSeparatorToTrue(string input)
+    {
+        // Act
+        var parser = new ResultParser(input);
+        
+        // Assert
+        Assert.True(parser.IsMissingContestantResultSeparator);
+        
+        Assert.True(parser.HasNoContestant1Name);
+        Assert.True(parser.HasNoContestant1Result);
+        Assert.True(parser.HasNoContestant1Score);
+        
+        Assert.True(parser.HasNoContestant2Name);
+        Assert.True(parser.HasNoContestant2Result);
+        Assert.True(parser.HasNoContestant2Score);
+        
+        Assert.Empty(parser.Contestant1Name);
+        Assert.Equal(0, parser.Contestant1Score);
+        
+        Assert.Empty(parser.Contestant2Name);
+        Assert.Equal(0, parser.Contestant2Score);
+    }
+    
+    /// <summary>
+    ///     Tests that the constructor sets <see cref="ResultParser.HasMultipleContestantResultSeparators" />
+    ///     to <c>true</c> when the input contains multiple contestant result separators, regardless of spacing.
+    /// </summary>
+    /// <param name="input">The input to parse.</param>
+    [Theory]
+    [InlineData(
+        $"Alice 10{ResultParser.ContestantResultSeparator} Bob 20{ResultParser.ContestantResultSeparator} Charlie 30")]
+    [InlineData(
+        $"Alice 10 {ResultParser.ContestantResultSeparator} Bob 20 {ResultParser.ContestantResultSeparator} Charlie 30")]
+    [InlineData(
+        $"Alice 10 {ResultParser.ContestantResultSeparator}Bob 20 {ResultParser.ContestantResultSeparator}Charlie 30")]
+    [InlineData(
+        $"Alice 10{ResultParser.ContestantResultSeparator} Bob 20 {ResultParser.ContestantResultSeparator}Charlie 30")]
+    [InlineData(
+        $"Alice 10 {ResultParser.ContestantResultSeparator} Bob 20{ResultParser.ContestantResultSeparator} Charlie 30")]
+    [InlineData(
+        $"Alice 10{ResultParser.ContestantResultSeparator}Bob 20{ResultParser.ContestantResultSeparator}Charlie 30")]
+    public void Ctor_WithMultipleContestantResultSeparators_SetsHasMultipleContestantResultSeparatorsToTrue(
+        string input)
+    {
+        // Act
+        var parser = new ResultParser(input);
+        
+        // Assert
+        Assert.True(parser.HasMultipleContestantResultSeparators);
+        Assert.False(parser.IsMissingContestantResultSeparator);
+        
+        Assert.True(parser.HasNoContestant1Name);
+        Assert.True(parser.HasNoContestant1Result);
+        Assert.True(parser.HasNoContestant1Score);
+        
+        Assert.True(parser.HasNoContestant2Name);
+        Assert.True(parser.HasNoContestant2Result);
+        Assert.True(parser.HasNoContestant2Score);
+        
+        Assert.Empty(parser.Contestant1Name);
+        Assert.Equal(0, parser.Contestant1Score);
+        
+        Assert.Empty(parser.Contestant2Name);
+        Assert.Equal(0, parser.Contestant2Score);
+    }
+
+    /// <summary>
+    ///     Tests that the constructor sets <see cref="ResultParser.HasNoContestant1Name" />
+    ///     to <c>true</c> when the input is missing the first contestant name, regardless of spacing.
+    /// </summary>
+    /// <param name="input">The input to parse.</param>
+    /// <param name="expectedContestant1Name">The expected name of the first contestant.</param>
+    /// <param name="expectedContestant1Score">The expected score of the first contestant.</param>
+    /// <param name="expectedContestant2Name">The expected name of the second contestant.</param>
+    /// <param name="expectedContestant2Score">The expected score of the second contestant.</param>
+    [Theory]
+    [InlineData(
+        $"10{ResultParser.ContestantResultSeparator} Bob 20",
+        "",
+        10,
+        "Bob",
+        20)]
+    [InlineData(
+        $" 10{ResultParser.ContestantResultSeparator} Bob 20",
+        "",
+        10,
+        "Bob",
+        20)]
+    [InlineData(
+        $"10{ResultParser.ContestantResultSeparator} Bob 20 ",
+        "",
+        10,
+        "Bob",
+        20)]
+    [InlineData(
+        $" 10{ResultParser.ContestantResultSeparator} Bob 20 ",
+        "",
+        10,
+        "Bob",
+        20)]
+    [InlineData(
+        $"10{ResultParser.ContestantResultSeparator}\tBob 20",
+        "",
+        10,
+        "Bob",
+        20)]
+    [InlineData(
+        $" 10{ResultParser.ContestantResultSeparator}\tBob 20",
+        "",
+        10,
+        "Bob",
+        20)]
+    public void Ctor_WithNoContestant1Name_SetsHasNoContestant1NameToTrue(
+        string input,
+        string expectedContestant1Name,
+        ushort expectedContestant1Score,
+        string expectedContestant2Name,
+        ushort expectedContestant2Score)
+    {
+        // Act
+        var parser = new ResultParser(input);
+        
+        // Assert
+        Assert.False(parser.HasMultipleContestantResultSeparators);
+        Assert.False(parser.IsMissingContestantResultSeparator);
+        
+        Assert.True(parser.HasNoContestant1Name);
+        Assert.False(parser.HasNoContestant1Result);
+        Assert.False(parser.HasNoContestant1Score);
+        
+        Assert.False(parser.HasNoContestant2Name);
+        Assert.False(parser.HasNoContestant2Result);
+        Assert.False(parser.HasNoContestant2Score);
+        
+        Assert.Equal(expectedContestant1Name, parser.Contestant1Name);
+        Assert.Equal(expectedContestant1Score, parser.Contestant1Score);
+        
+        Assert.Equal(expectedContestant2Name, parser.Contestant2Name);
+        Assert.Equal(expectedContestant2Score, parser.Contestant2Score);
+    }
+
+    /// <summary>
+    ///     Tests that the constructor sets <see cref="ResultParser.HasNoContestant1Result" />
+    ///     to <c>true</c> when the input is missing the first contestant result, regardless of spacing.
+    /// </summary>
+    /// <param name="input">The input to parse.</param>
+    /// <param name="expectedContestant2Name">The expected name of the second contestant.</param>
+    /// <param name="expectedContestant2Score">The expected score of the second contestant.</param>
+    [Theory]
+    [InlineData(
+        $"{ResultParser.ContestantResultSeparator} Bob 20",
+        "Bob",
+        20)]
+    [InlineData(
+        $" {ResultParser.ContestantResultSeparator} Bob 20",
+        "Bob",
+        20)]
+    [InlineData(
+        $"{ResultParser.ContestantResultSeparator} Bob 20 ",
+        "Bob",
+        20)]
+    [InlineData(
+        $" {ResultParser.ContestantResultSeparator} Bob 20 ",
+        "Bob",
+        20)]
+    [InlineData(
+        $" \t {ResultParser.ContestantResultSeparator} Bob 20 ",
+        "Bob",
+        20)]
+    [InlineData(
+        $" \t {ResultParser.ContestantResultSeparator} Bob 20 \t ",
+        "Bob",
+        20)]
+    public void Ctor_WithNoContestant1Result_SetsHasNoContestant1ResultToTrue(
+        string input,
+        string expectedContestant2Name,
+        ushort expectedContestant2Score)
+    {
+        // Act
+        var parser = new ResultParser(input);
+        
+        // Assert
+        Assert.False(parser.HasMultipleContestantResultSeparators);
+        Assert.False(parser.IsMissingContestantResultSeparator);
+        
+        Assert.True(parser.HasNoContestant1Name);
+        Assert.True(parser.HasNoContestant1Result);
+        Assert.True(parser.HasNoContestant1Score);
+        
+        Assert.False(parser.HasNoContestant2Name);
+        Assert.False(parser.HasNoContestant2Result);
+        Assert.False(parser.HasNoContestant2Score);
+        
+        Assert.Empty(parser.Contestant1Name);
+        Assert.Equal(0, parser.Contestant1Score);
+        
+        Assert.Equal(expectedContestant2Name, parser.Contestant2Name);
+        Assert.Equal(expectedContestant2Score, parser.Contestant2Score);
+    }
+    
+    /// <summary>
+    ///     Tests that the constructor sets <see cref="ResultParser.HasNoContestant1Score" />
+    ///     to <c>true</c> when the input is missing the first contestant score, regardless of spacing.
+    /// </summary>
+    /// <param name="input">The input to parse.</param>
+    /// <param name="expectedContestant1Name">The expected name of the first contestant.</param>
+    /// <param name="expectedContestant1Score">The expected score of the first contestant.</param>
+    /// <param name="expectedContestant2Name">The expected name of the second contestant.</param>
+    /// <param name="expectedContestant2Score">The expected score of the second contestant.</param>
+    [Theory]
+    [InlineData(
+        $"Alice{ResultParser.ContestantResultSeparator} Bob 20",
+        "Alice",
+        0,
+        "Bob",
+        20)]
+    [InlineData(
+        $"Alice {ResultParser.ContestantResultSeparator} Bob 20",
+        "Alice",
+        0,
+        "Bob",
+        20)]
+    [InlineData(
+        $"Alice{ResultParser.ContestantResultSeparator} Bob 20 ",
+        "Alice",
+        0,
+        "Bob",
+        20)]
+    [InlineData(
+        $"Alice {ResultParser.ContestantResultSeparator} Bob 20 ",
+        "Alice",
+        0,
+        "Bob",
+        20)]
+    [InlineData(
+        $"Alice{ResultParser.ContestantResultSeparator}\tBob 20",
+        "Alice",
+        0,
+        "Bob",
+        20)]
+    [InlineData(
+        $"Alice {ResultParser.ContestantResultSeparator}\tBob 20",
+        "Alice",
+        0,
+        "Bob",
+        20)]
+    public void Ctor_WithNoContestant1Score_SetsHasNoContestant1ScoreToTrue(
+        string input,
+        string expectedContestant1Name,
+        ushort expectedContestant1Score,
+        string expectedContestant2Name,
+        ushort expectedContestant2Score)
+    {
+        // Act
+        var parser = new ResultParser(input);
+        
+        // Assert
+        Assert.False(parser.HasMultipleContestantResultSeparators);
+        Assert.False(parser.IsMissingContestantResultSeparator);
+        
+        Assert.False(parser.HasNoContestant1Name);
+        Assert.False(parser.HasNoContestant1Result);
+        Assert.True(parser.HasNoContestant1Score);
+        
+        Assert.False(parser.HasNoContestant2Name);
+        Assert.False(parser.HasNoContestant2Result);
+        Assert.False(parser.HasNoContestant2Score);
+        
+        Assert.Equal(expectedContestant1Name, parser.Contestant1Name);
+        Assert.Equal(expectedContestant1Score, parser.Contestant1Score);
+        
+        Assert.Equal(expectedContestant2Name, parser.Contestant2Name);
+        Assert.Equal(expectedContestant2Score, parser.Contestant2Score);
+    }
+
+    /// <summary>
+    ///     Tests that the constructor sets <see cref="ResultParser.HasNoContestant2Name" />
+    ///     to <c>true</c> when the input is missing the second contestant name, regardless of spacing.
+    /// </summary>
+    /// <param name="input">The input to parse.</param>
+    /// <param name="expectedContestant1Name">The expected name of the first contestant.</param>
+    /// <param name="expectedContestant1Score">The expected score of the first contestant.</param>
+    /// <param name="expectedContestant2Name">The expected name of the second contestant.</param>
+    /// <param name="expectedContestant2Score">The expected score of the second contestant.</param>
+    [Theory]
+    [InlineData(
+        $"Alice 20{ResultParser.ContestantResultSeparator} 10",
+        "Alice",
+        20,
+        "",
+        10)]
+    [InlineData(
+        $"Alice 20 {ResultParser.ContestantResultSeparator} 10",
+        "Alice",
+        20,
+        "",
+        10)]
+    [InlineData(
+        $"Alice 20{ResultParser.ContestantResultSeparator} 10 ",
+        "Alice",
+        20,
+        "",
+        10)]
+    [InlineData(
+        $"Alice 20 {ResultParser.ContestantResultSeparator} 10 ",
+        "Alice",
+        20,
+        "",
+        10)]
+    [InlineData(
+        $"\tAlice 20{ResultParser.ContestantResultSeparator}10",
+        "Alice",
+        20,
+        "",
+        10)]
+    [InlineData(
+        $"\tAlice 20 {ResultParser.ContestantResultSeparator} 10",
+        "Alice",
+        20,
+        "",
+        10)]
+    public void Ctor_WithNoContestant2Name_SetsHasNoContestant2NameToTrue(
+        string input,
+        string expectedContestant1Name,
+        ushort expectedContestant1Score,
+        string expectedContestant2Name,
+        ushort expectedContestant2Score)
+    {
+        // Act
+        var parser = new ResultParser(input);
+        
+        // Assert
+        Assert.False(parser.HasMultipleContestantResultSeparators);
+        Assert.False(parser.IsMissingContestantResultSeparator);
+        
+        Assert.False(parser.HasNoContestant1Name);
+        Assert.False(parser.HasNoContestant1Result);
+        Assert.False(parser.HasNoContestant1Score);
+        
+        Assert.True(parser.HasNoContestant2Name);
+        Assert.False(parser.HasNoContestant2Result);
+        Assert.False(parser.HasNoContestant2Score);
+        
+        Assert.Equal(expectedContestant1Name, parser.Contestant1Name);
+        Assert.Equal(expectedContestant1Score, parser.Contestant1Score);
+        
+        Assert.Equal(expectedContestant2Name, parser.Contestant2Name);
+        Assert.Equal(expectedContestant2Score, parser.Contestant2Score);
+    }
+
+    /// <summary>
+    ///     Tests that the constructor sets <see cref="ResultParser.HasNoContestant2Result" />
+    ///     to <c>true</c> when the input is missing the second contestant result, regardless of spacing.
+    /// </summary>
+    /// <param name="input">The input to parse.</param>
+    /// <param name="expectedContestant1Name">The expected name of the first contestant.</param>
+    /// <param name="expectedContestant1Score">The expected score of the first contestant.</param>
+    [Theory]
+    [InlineData(
+        $"Alice 10{ResultParser.ContestantResultSeparator}",
+        "Alice",
+        10)]
+    [InlineData($"Alice 10{ResultParser.ContestantResultSeparator} ",
+        "Alice",
+        10)]
+    [InlineData(
+        $"Alice 10 {ResultParser.ContestantResultSeparator}",
+        "Alice",
+        10)]
+    [InlineData(
+        $"Alice 10 {ResultParser.ContestantResultSeparator} ",
+        "Alice",
+        10)]
+    [InlineData(
+        $"Alice 10 {ResultParser.ContestantResultSeparator}\t",
+        "Alice",
+        10)]
+    [InlineData(
+        $"Alice 10{ResultParser.ContestantResultSeparator}\t",
+        "Alice",
+        10)]
+    public void Ctor_WithNoContestant2Result_SetsHasNoContestant2ResultToTrue(
+        string input,
+        string expectedContestant1Name,
+        ushort expectedContestant1Score)
+    {
+        // Act
+        var parser = new ResultParser(input);
+
+        // Assert
+        Assert.False(parser.HasMultipleContestantResultSeparators);
+        Assert.False(parser.IsMissingContestantResultSeparator);
+        
+        Assert.False(parser.HasNoContestant1Name);
+        Assert.False(parser.HasNoContestant1Result);
+        Assert.False(parser.HasNoContestant1Score);
+        
+        Assert.True(parser.HasNoContestant2Name);
+        Assert.True(parser.HasNoContestant2Result);
+        Assert.True(parser.HasNoContestant2Score);
+        
+        Assert.Equal(expectedContestant1Name, parser.Contestant1Name);
+        Assert.Equal(expectedContestant1Score, parser.Contestant1Score);
+        
+        Assert.Empty(parser.Contestant2Name);
+        Assert.Equal(0, parser.Contestant2Score);
+    }
+    
+    /// <summary>
+    ///     Tests that the constructor sets <see cref="ResultParser.HasNoContestant2Score" />
+    ///     to <c>true</c> when the input is missing the second contestant score, regardless of spacing.
+    /// </summary>
+    /// <param name="input">The input to parse.</param>
+    /// <param name="expectedContestant1Name">The expected name of the first contestant.</param>
+    /// <param name="expectedContestant1Score">The expected score of the first contestant.</param>
+    /// <param name="expectedContestant2Name">The expected name of the second contestant.</param>
+    /// <param name="expectedContestant2Score">The expected score of the second contestant.</param>
+    [Theory]
+    [InlineData(
+        $"Alice 20{ResultParser.ContestantResultSeparator} Bob",
+        "Alice",
+        20,
+        "Bob",
+        0)]
+    [InlineData(
+        $"Alice 20 {ResultParser.ContestantResultSeparator} Bob",
+        "Alice",
+        20,
+        "Bob",
+        0)]
+    [InlineData(
+        $"Alice 20{ResultParser.ContestantResultSeparator} Bob ",
+        "Alice",
+        20,
+        "Bob",
+        0)]
+    [InlineData(
+        $"Alice 20 {ResultParser.ContestantResultSeparator} Bob ",
+        "Alice",
+        20,
+        "Bob",
+        0)]
+    [InlineData(
+        $"\tAlice 20{ResultParser.ContestantResultSeparator}Bob",
+        "Alice",
+        20,
+        "Bob",
+        0)]
+    [InlineData(
+        $"\tAlice 20 {ResultParser.ContestantResultSeparator}Bob ",
+        "Alice",
+        20,
+        "Bob",
+        0)]
+    public void Ctor_WithNoContestant2Score_SetsHasNoContestant2ScoreToTrue(
+        string input,
+        string expectedContestant1Name,
+        ushort expectedContestant1Score,
+        string expectedContestant2Name,
+        ushort expectedContestant2Score)
+    {
+        // Act
+        var parser = new ResultParser(input);
+        
+        // Assert
+        Assert.False(parser.HasMultipleContestantResultSeparators);
+        Assert.False(parser.IsMissingContestantResultSeparator);
+        
+        Assert.False(parser.HasNoContestant1Name);
+        Assert.False(parser.HasNoContestant1Result);
+        Assert.False(parser.HasNoContestant1Score);
+        
+        Assert.False(parser.HasNoContestant2Name);
+        Assert.False(parser.HasNoContestant2Result);
+        Assert.True(parser.HasNoContestant2Score);
+        
+        Assert.Equal(expectedContestant1Name, parser.Contestant1Name);
+        Assert.Equal(expectedContestant1Score, parser.Contestant1Score);
+        
+        Assert.Equal(expectedContestant2Name, parser.Contestant2Name);
+        Assert.Equal(expectedContestant2Score, parser.Contestant2Score);
+    }
+}

--- a/test/Rankings.UnitTests/ProgramTests.cs
+++ b/test/Rankings.UnitTests/ProgramTests.cs
@@ -9,8 +9,31 @@ namespace Rankings.UnitTests;
 public class ProgramTests
 {
     /// <summary>
+    ///     Tests that the <see cref="Program.Main"/> method configures the root command with the expected options.
+    /// </summary>
+    [Fact]
+    public void Main_ConfiguresRootCommandWithExpectedOptions()
+    {
+        // Arrange
+        var expectedOptions = new[]
+        {
+            "--help",
+            "--version",
+            CommandLineOptions.ResultOption[0],
+        };
+
+        // Act
+        var optionsQuery = Program.ConfiguredOptions.Select(o => o.Name);
+        var actualOptions = optionsQuery.ToArray();
+
+        // Assert
+        Assert.Equal(expectedOptions, actualOptions);
+    }
+    
+    /// <summary>
     ///     Tests that the <see cref="Program.Main"/> method displays help when called with the "--help" argument.
     /// </summary>
+    /// <param name="arg">The help argument to test.</param>
     [Theory]
     [InlineData("-?")]
     [InlineData("-h")]

--- a/test/Rankings.UnitTests/Rankings.UnitTests.csproj
+++ b/test/Rankings.UnitTests/Rankings.UnitTests.csproj
@@ -24,6 +24,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+        <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/test/Rankings.UnitTests/Validators/ResultValidatorTests.cs
+++ b/test/Rankings.UnitTests/Validators/ResultValidatorTests.cs
@@ -1,0 +1,69 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+using System.CommandLine;
+using Rankings.Extensions;
+using Rankings.Parsers;
+using Rankings.Validators;
+
+namespace Rankings.UnitTests.Validators;
+
+/// <summary>
+///     Unit tests for the <see cref="ResultValidator" /> class.
+/// </summary>
+public class ResultValidatorTests
+{
+    /// <summary>
+    ///     Tests that the validator adds an error when the input has multiple contestant result separators.
+    /// </summary>
+    /// <param name="input">The input string to validate.</param>
+    /// <param name="expected">The expected error message.</param>
+    [Theory]
+    [InlineData("--result", "Required argument missing for option: '--result'.")]
+    [InlineData(
+        "--result \"1\n2\"",
+        "A result must not contain any line breaks, it must be a single line.")]
+    [InlineData(
+        "--result \"1\r2\"",
+        "A result must not contain any line breaks, it must be a single line.")]
+    [InlineData(
+        "--result \"1\r\n2\"",
+        "A result must not contain any line breaks, it must be a single line.")]
+    [InlineData(
+        $"--result \"1{ResultParser.ContestantResultSeparator}2{ResultParser.ContestantResultSeparator}3\"",
+        $"A result can only contain one {ResultParser.ContestantResultSeparator} symbol.")]
+    [InlineData(
+        "--result \"12345\"",
+        $"A result must be separated into two parts by the {ResultParser.ContestantResultSeparator} symbol; one part for each contestant's name and score.")]
+    [InlineData(
+        $"--result \"{ResultParser.ContestantResultSeparator} Bob 20\"",
+        "A result must include the results for both contestants. Cannot find a result for contestant 1.")]
+    [InlineData(
+        $"--result \"Alice 10{ResultParser.ContestantResultSeparator}\"",
+        "A result must include the results for both contestants. Cannot find a result for contestant 2.")]
+    [InlineData(
+        $"--result \"10{ResultParser.ContestantResultSeparator} Bob 20\"",
+        "A result must include names for both contestants. Cannot find a name for contestant 1.")]
+    [InlineData(
+        $"--result \"Alice{ResultParser.ContestantResultSeparator} Bob 20\"",
+        "A result must include scores for both contestants. Cannot find a score for contestant 1.")]
+    [InlineData(
+        $"--result \"Alice 10{ResultParser.ContestantResultSeparator}20\"",
+        "A result must include names for both contestants. Cannot find a name for contestant 2.")]
+    [InlineData(
+        $"--result \"Alice 10{ResultParser.ContestantResultSeparator} Bob\"",
+        "A result must include scores for both contestants. Cannot find a score for contestant 2.")]
+    public void Validate_WithError_AddsError(string input, string expected)
+    {
+        // Arrange
+        var rootCommand = new RootCommand();
+        rootCommand.AddResultOption();
+
+        // Act
+        var parseResult = rootCommand.Parse(input);
+        
+        // Assert
+        Assert.Single(parseResult.Errors);
+        Assert.Equal(expected, parseResult.Errors[0].Message);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new command-line option for adding contest results, refactors the command-line parsing logic, and adds robust parsing and validation for contest result input. It also improves documentation and string resource management for error handling and option descriptions.

### Command-Line Option and Parsing

* Added a new `--result`/`-r` option to the application via the new `CommandLineOptions` record and integrated it into the root command using the `AddResultOption` extension method in `RankingsRootCommandExtensions`. This option enables users to input contest results directly from the command line.
* Refactored `Program.cs` to use the new root command setup and expose configured options, ensuring the new result option is registered and handled correctly.

### Contest Result Parsing and Validation

* Implemented the `ResultParser` class to robustly parse and validate contest result input, including checks for correct structure, missing data, and invalid formats. It provides detailed flags and error handling for various input issues.

### Resource Localization and Error Messages

* Extended `Common.Designer.cs` and `Common.resx` to include localized strings for new validation errors, option descriptions, and input requirements, ensuring clear feedback to users.

### Documentation and Project Structure

* Updated `README.md` to clarify the required .NET SDK, document the project structure, and add sections on AI usage, code quality tools, building, running, and testing the application.