### PR TITLE
feat: Add file option for importing contestant results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ their respective terminals.
 
 To run the app, please ensure that [.NET 9.0 SDK](https://dotnet.microsoft.com/download) is installed.
 
+### GitHub Project
+
+The project is hosted on GitHub within the [Rankings Project](https://github.com/users/SebGSX/projects/10).
+
+> *Note:* The project uses a simple Kanban board with user and enabler stories to track progress.
+
 ### Project Structure
 The project is structured as follows:
 

--- a/src/Rankings/CommandLineOptions.cs
+++ b/src/Rankings/CommandLineOptions.cs
@@ -9,7 +9,16 @@ namespace Rankings;
 public abstract record CommandLineOptions
 {
     /// <summary>
-    ///     Represents the result option and its aliases.
+    ///     Represents the file option and its aliases used to import contestant results from a file.
+    /// </summary>
+    /// <remarks>The first element is the primary name, and the rest are aliases.</remarks>
+    public static string[] FileOption
+    {
+        get;
+    } = ["--file", "-f"];
+    
+    /// <summary>
+    ///     Represents the result option and its aliases used to import contestant results from the command line.
     /// </summary>
     /// <remarks>The first element is the primary name, and the rest are aliases.</remarks>
     public static string[] ResultOption

--- a/src/Rankings/Extensions/RankingsRootCommandExtensions.cs
+++ b/src/Rankings/Extensions/RankingsRootCommandExtensions.cs
@@ -14,6 +14,26 @@ namespace Rankings.Extensions;
 public static class RankingsRootCommandExtensions
 {
     /// <summary>
+    ///     Adds the file option to the root command.
+    /// </summary>
+    /// <param name="rootCommand">The root command receiving the option.</param>
+    /// <returns>The root command with the option added.</returns>
+    public static RootCommand AddFileOption(this RootCommand rootCommand)
+    {
+        var fileOption = new Option<FileInfo>(
+            name: CommandLineOptions.FileOption[0],
+            aliases: CommandLineOptions.FileOption[1..])
+        {
+            Description = Common.FileOption_Description,
+            Validators = { FileValidator.Validate() }
+        };
+        
+        rootCommand.Options.Add(fileOption);
+        
+        return rootCommand;
+    }
+    
+    /// <summary>
     ///     Adds the result option to the root command.
     /// </summary>
     /// <param name="rootCommand">The root command receiving the option.</param>

--- a/src/Rankings/Program.cs
+++ b/src/Rankings/Program.cs
@@ -24,6 +24,7 @@ public abstract class Program
     public static void Main(string[] args)
     {
         RootCommand.AddResultOption();
+        RootCommand.AddFileOption();
         
         // Automatically handles unhandled exceptions thrown during parsing or invocation.
         RootCommand.Parse(args).Invoke();

--- a/src/Rankings/Resources/Common.Designer.cs
+++ b/src/Rankings/Resources/Common.Designer.cs
@@ -78,7 +78,7 @@ namespace Rankings.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Imports a set of results from the specified file into the results file. Eeach result must be in the form: &quot;&lt;CONTESTANT-1&gt; &lt;SCORE-1&gt;, &lt;CONTESTANT-2&gt; &lt;SCORE-2&gt;&quot;. See help for the --result option for further information..
+        ///   Looks up a localized string similar to Imports a set of results from the specified file into the results file. Each result must be in the form: &quot;&lt;CONTESTANT-1&gt; &lt;SCORE-1&gt;, &lt;CONTESTANT-2&gt; &lt;SCORE-2&gt;&quot;. See help for the --result option for further information..
         /// </summary>
         internal static string FileOption_Description {
             get {

--- a/src/Rankings/Resources/Common.Designer.cs
+++ b/src/Rankings/Resources/Common.Designer.cs
@@ -78,6 +78,33 @@ namespace Rankings.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Imports a set of results from the specified file into the results file. Eeach result must be in the form: &quot;&lt;CONTESTANT-1&gt; &lt;SCORE-1&gt;, &lt;CONTESTANT-2&gt; &lt;SCORE-2&gt;&quot;. See help for the --result option for further information..
+        /// </summary>
+        internal static string FileOption_Description {
+            get {
+                return ResourceManager.GetString("FileOption_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The file specified does not exist..
+        /// </summary>
+        internal static string FileOption_Validation_FileDoesNotExist {
+            get {
+                return ResourceManager.GetString("FileOption_Validation_FileDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The file specified is empty..
+        /// </summary>
+        internal static string FileOption_Validation_FileIsEmpty {
+            get {
+                return ResourceManager.GetString("FileOption_Validation_FileIsEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Adds a single contest result to the results file. A result must be in the form: &quot;&lt;CONTESTANT-1&gt; &lt;SCORE-1&gt;, &lt;CONTESTANT-2&gt; &lt;SCORE-2&gt;&quot;. Replace &lt;CONTESTANT-n&gt; with the contestants&apos; names such as, Team One, Team Two, etc. Names cannot start with - or --, and they cannot include the {0} symbol. Scores must be non-negative, whole numbers without any separator symbols, which means for example that 1000 is appropriate but 1,000 is not. Example: rankings -r &quot;My Team 1{0} Other Team 0&quot;.
         /// </summary>
         internal static string ResultOption_Description {

--- a/src/Rankings/Resources/Common.resx
+++ b/src/Rankings/Resources/Common.resx
@@ -49,7 +49,7 @@
         <value>A result must include scores for both contestants. Cannot find a score for contestant {0}.</value>
     </data>
     <data name="FileOption_Description" xml:space="preserve">
-        <value>Imports a set of results from the specified file into the results file. Eeach result must be in the form: "&lt;CONTESTANT-1&gt; &lt;SCORE-1&gt;, &lt;CONTESTANT-2&gt; &lt;SCORE-2&gt;". See help for the --result option for further information.</value>
+        <value>Imports a set of results from the specified file into the results file. Each result must be in the form: "&lt;CONTESTANT-1&gt; &lt;SCORE-1&gt;, &lt;CONTESTANT-2&gt; &lt;SCORE-2&gt;". See help for the --result option for further information.</value>
     </data>
     <data name="FileOption_Validation_FileDoesNotExist" xml:space="preserve">
         <value>The file specified does not exist.</value>

--- a/src/Rankings/Resources/Common.resx
+++ b/src/Rankings/Resources/Common.resx
@@ -48,4 +48,13 @@
     <data name="ResultOption_Validation_NoContestantScore" xml:space="preserve">
         <value>A result must include scores for both contestants. Cannot find a score for contestant {0}.</value>
     </data>
+    <data name="FileOption_Description" xml:space="preserve">
+        <value>Imports a set of results from the specified file into the results file. Eeach result must be in the form: "&lt;CONTESTANT-1&gt; &lt;SCORE-1&gt;, &lt;CONTESTANT-2&gt; &lt;SCORE-2&gt;". See help for the --result option for further information.</value>
+    </data>
+    <data name="FileOption_Validation_FileDoesNotExist" xml:space="preserve">
+        <value>The file specified does not exist.</value>
+    </data>
+    <data name="FileOption_Validation_FileIsEmpty" xml:space="preserve">
+        <value>The file specified is empty.</value>
+    </data>
 </root>

--- a/src/Rankings/Validators/FileValidator.cs
+++ b/src/Rankings/Validators/FileValidator.cs
@@ -34,7 +34,7 @@ public abstract class FileValidator
              */
             var validations = new List<(bool IsError, string ErrorMessage)>
             {
-                (!fileExists, string.Format(Common.FileOption_Validation_FileDoesNotExist, fileInfo.FullName))
+                (!fileExists, Common.FileOption_Validation_FileDoesNotExist)
             };
             
             foreach (var (isError, errorMessage) in validations)

--- a/src/Rankings/Validators/FileValidator.cs
+++ b/src/Rankings/Validators/FileValidator.cs
@@ -1,0 +1,48 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Diagnostics;
+using Rankings.Resources;
+
+namespace Rankings.Validators;
+
+/// <summary>
+///     Validates the file option.
+/// </summary>
+public abstract class FileValidator
+{
+    /// <summary>
+    ///     Ensures that the option result contains a valid file with contestant results.
+    /// </summary>
+    /// <returns>An action that validates the option result.</returns>
+    public static Action<OptionResult> Validate()
+    {
+        return result =>
+        {
+            // The result should never be null.
+            Debug.Assert(result != null);
+            Debug.Assert(result.GetValueOrDefault<FileInfo>() != null);
+            
+            var fileInfo = result.GetValueOrDefault<FileInfo>();
+            var fileExists = fileInfo.Exists;
+            
+            /*
+             * Identify validation errors in the order they should be reported.
+             * While only one validation is currently performed, this structure follows the established pattern and
+             * provides for extension in the future with minimal effort.
+             */
+            var validations = new List<(bool IsError, string ErrorMessage)>
+            {
+                (!fileExists, string.Format(Common.FileOption_Validation_FileDoesNotExist, fileInfo.FullName))
+            };
+            
+            foreach (var (isError, errorMessage) in validations)
+            {
+                if (!isError) continue;
+                result.AddError(errorMessage);
+                return;
+            }
+        };
+    }
+}

--- a/test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs
+++ b/test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs
@@ -3,7 +3,6 @@
 
 using Rankings.Extensions;
 using System.CommandLine;
-using System.Diagnostics;
 
 namespace Rankings.UnitTests.Extensions;
 
@@ -12,6 +11,30 @@ namespace Rankings.UnitTests.Extensions;
 /// </summary>
 public class RankingsRootCommandExtensionsTests
 {
+    /// <summary>
+    ///     Tests that the <see cref="RankingsRootCommandExtensions.AddFileOption" /> method correctly adds the
+    ///     result option to a root command.
+    /// </summary>
+    [Fact]
+    public void AddFileOption_AddsOptionToRootCommand()
+    {
+        // Arrange
+        var rootCommand = new RootCommand();
+        const string expectedOptionName = "--file";
+        string[] expectedOptionAliases = ["-f"];
+        
+        // Act
+        rootCommand.AddFileOption();
+        var option = rootCommand.Options.FirstOrDefault(o => o.Name == expectedOptionName);
+        
+        // Assert
+        Assert.NotNull(option);
+        Assert.Equal(expectedOptionName, option.Name);
+        Assert.Equal(expectedOptionAliases, option.Aliases);
+        Assert.NotNull(option.Description);
+        Assert.NotEmpty(option.Description);
+    }
+    
     /// <summary>
     ///     Tests that the <see cref="RankingsRootCommandExtensions.AddResultOption" /> method correctly adds the
     ///     result option to a root command.

--- a/test/Rankings.UnitTests/ProgramTests.cs
+++ b/test/Rankings.UnitTests/ProgramTests.cs
@@ -20,6 +20,7 @@ public class ProgramTests
             "--help",
             "--version",
             CommandLineOptions.ResultOption[0],
+            CommandLineOptions.FileOption[0]
         };
 
         // Act

--- a/test/Rankings.UnitTests/Validators/FileValidatorTests.cs
+++ b/test/Rankings.UnitTests/Validators/FileValidatorTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+using System.CommandLine;
+using Rankings.Extensions;
+using Rankings.Validators;
+
+namespace Rankings.UnitTests.Validators;
+
+/// <summary>
+///     Unit tests for the <see cref="FileValidator" /> class.
+/// </summary>
+public class FileValidatorTests
+{
+    /// <summary>
+    ///     Tests that the validator adds an error when the input is invalid.
+    /// </summary>
+    /// <param name="input">The input string to validate.</param>
+    /// <param name="expected">The expected error message.</param>
+    [Theory]
+    [InlineData("--file", "Required argument missing for option: '--file'.")]
+    [InlineData("--file \"none-existent.txt\"", "The file specified does not exist.")]
+    public void Validate_WithError_AddsError(string input, string expected)
+    {
+        // Arrange
+        var rootCommand = new RootCommand();
+        rootCommand.AddFileOption();
+
+        // Act
+        var parseResult = rootCommand.Parse(input);
+        
+        // Assert
+        Assert.Single(parseResult.Errors);
+        Assert.Equal(expected, parseResult.Errors[0].Message);
+    }
+}

--- a/test/Rankings.UnitTests/Validators/ResultValidatorTests.cs
+++ b/test/Rankings.UnitTests/Validators/ResultValidatorTests.cs
@@ -14,7 +14,7 @@ namespace Rankings.UnitTests.Validators;
 public class ResultValidatorTests
 {
     /// <summary>
-    ///     Tests that the validator adds an error when the input has multiple contestant result separators.
+    ///     Tests that the validator adds an error when the input is invalid.
     /// </summary>
     /// <param name="input">The input string to validate.</param>
     /// <param name="expected">The expected error message.</param>


### PR DESCRIPTION
This pull request introduces a new file import option to the Rankings application, allowing users to import contestant results from a file via the command line. The changes include updates to the command-line interface, validation logic for the new option, resource strings for error handling and help text, and comprehensive unit tests to ensure correct behavior.

### Command-line Interface Enhancements
* Added a new `--file` (`-f`) option to `CommandLineOptions` for importing results from a file, including documentation and remarks.
* Updated `Program.cs` to register the new file option with the root command, ensuring it is available during command execution.
* Extended `RankingsRootCommandExtensions` with an `AddFileOption` method to add the file option, including description and validation setup.

### Validation Logic
* Implemented `FileValidator` to check if the specified file exists, with infrastructure for future validation extensions.

### Resource and Documentation Updates
* Added localized resource strings for the file option description and validation error messages, and updated the README to reference the GitHub project board.

### Unit Testing
* Added unit tests for `AddFileOption` to verify correct option registration and configuration.
* Added unit tests for `FileValidator` to ensure validation errors are reported for missing or non-existent files.
* Updated existing tests to include the new file option in expected command-line options.

These changes collectively improve the application's flexibility in importing results and ensure robust error handling and user guidance.