### PR TITLE
feat: Add append-file and append-result subcommands to command line i…

### DIFF
--- a/src/Rankings/CommandLineSubCommands.cs
+++ b/src/Rankings/CommandLineSubCommands.cs
@@ -1,0 +1,20 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+namespace Rankings;
+
+/// <summary>
+///     Represents the command line subcommands.
+/// </summary>
+public abstract record CommandLineSubCommands
+{
+    /// <summary>
+    ///     Represents the append-file subcommand used to append contestant results from a file.
+    /// </summary>
+    public static string AppendFile { get; } = "append-file";
+    
+    /// <summary>
+    ///     Represents the append-result subcommand used to append a contestant result from the command line.
+    /// </summary>
+    public static string AppendResult { get; } = "append-result";
+}

--- a/src/Rankings/CommandLineSubcommands.cs
+++ b/src/Rankings/CommandLineSubcommands.cs
@@ -6,7 +6,7 @@ namespace Rankings;
 /// <summary>
 ///     Represents the command line subcommands.
 /// </summary>
-public abstract record CommandLineSubCommands
+public abstract record CommandLineSubcommands
 {
     /// <summary>
     ///     Represents the append-file subcommand used to append contestant results from a file.

--- a/src/Rankings/Extensions/RankingsRootCommandExtensions.cs
+++ b/src/Rankings/Extensions/RankingsRootCommandExtensions.cs
@@ -14,12 +14,16 @@ namespace Rankings.Extensions;
 public static class RankingsRootCommandExtensions
 {
     /// <summary>
-    ///     Adds the file option to the root command.
+    ///     Adds the append file subcommand to the root command.
     /// </summary>
-    /// <param name="rootCommand">The root command receiving the option.</param>
-    /// <returns>The root command with the option added.</returns>
-    public static RootCommand AddFileOption(this RootCommand rootCommand)
+    /// <param name="rootCommand">The root command receiving the subcommand.</param>
+    /// <returns>The root command with the configured subcommand added.</returns>
+    public static RootCommand AddAppendFileSubCommand(this RootCommand rootCommand)
     {
+        var appendFileCommand = new Command(
+            CommandLineSubCommands.AppendFile,
+            Common.AppendFile_Subcommand_Description);
+        
         var fileOption = new Option<FileInfo>(
             name: CommandLineOptions.FileOption[0],
             aliases: CommandLineOptions.FileOption[1..])
@@ -28,18 +32,23 @@ public static class RankingsRootCommandExtensions
             Validators = { FileValidator.Validate() }
         };
         
-        rootCommand.Options.Add(fileOption);
+        appendFileCommand.Add(fileOption);
+        rootCommand.Add(appendFileCommand);
         
         return rootCommand;
     }
     
     /// <summary>
-    ///     Adds the result option to the root command.
+    ///     Adds the append result subcommand to the root command.
     /// </summary>
-    /// <param name="rootCommand">The root command receiving the option.</param>
-    /// <returns>The root command with the option added.</returns>
-    public static RootCommand AddResultOption(this RootCommand rootCommand)
+    /// <param name="rootCommand">The root command receiving the subcommand.</param>
+    /// <returns>The root command with the configured subcommand added.</returns>
+    public static RootCommand AddAppendResultSubCommand(this RootCommand rootCommand)
     {
+        var appendResultCommand = new Command(
+            CommandLineSubCommands.AppendResult,
+            Common.AppendResult_Subcommand_Description);
+        
         var resultOption = new Option<string>(
             name: CommandLineOptions.ResultOption[0],
             aliases: CommandLineOptions.ResultOption[1..])
@@ -48,7 +57,8 @@ public static class RankingsRootCommandExtensions
             Validators = { ResultValidator.Validate() }
         };
         
-        rootCommand.Options.Add(resultOption);
+        appendResultCommand.Add(resultOption);
+        rootCommand.Add(appendResultCommand);
         
         return rootCommand;
     }

--- a/src/Rankings/Extensions/RankingsRootCommandExtensions.cs
+++ b/src/Rankings/Extensions/RankingsRootCommandExtensions.cs
@@ -18,10 +18,10 @@ public static class RankingsRootCommandExtensions
     /// </summary>
     /// <param name="rootCommand">The root command receiving the subcommand.</param>
     /// <returns>The root command with the configured subcommand added.</returns>
-    public static RootCommand AddAppendFileSubCommand(this RootCommand rootCommand)
+    public static RootCommand AddAppendFileSubcommand(this RootCommand rootCommand)
     {
         var appendFileCommand = new Command(
-            CommandLineSubCommands.AppendFile,
+            CommandLineSubcommands.AppendFile,
             Common.AppendFile_Subcommand_Description);
         
         var fileOption = new Option<FileInfo>(
@@ -43,10 +43,10 @@ public static class RankingsRootCommandExtensions
     /// </summary>
     /// <param name="rootCommand">The root command receiving the subcommand.</param>
     /// <returns>The root command with the configured subcommand added.</returns>
-    public static RootCommand AddAppendResultSubCommand(this RootCommand rootCommand)
+    public static RootCommand AddAppendResultSubcommand(this RootCommand rootCommand)
     {
         var appendResultCommand = new Command(
-            CommandLineSubCommands.AppendResult,
+            CommandLineSubcommands.AppendResult,
             Common.AppendResult_Subcommand_Description);
         
         var resultOption = new Option<string>(

--- a/src/Rankings/Program.cs
+++ b/src/Rankings/Program.cs
@@ -15,7 +15,7 @@ public abstract class Program
     /// <summary>
     ///     Represents the root command of the application.
     /// </summary>
-    private static RootCommand _rootCommand;
+    private static RootCommand? _rootCommand;
     
     /// <summary>
     ///     The main entry point for the application.
@@ -24,8 +24,8 @@ public abstract class Program
     public static void Main(string[] args)
     {
         _rootCommand = new RootCommand(Common.RootCommand_Description);
-        _rootCommand.AddAppendFileSubCommand();
-        _rootCommand.AddAppendResultSubCommand();
+        _rootCommand.AddAppendFileSubcommand();
+        _rootCommand.AddAppendResultSubcommand();
         _rootCommand.SetAction(_ => 0);
         
         // Automatically handles unhandled exceptions thrown during parsing or invocation.
@@ -40,5 +40,5 @@ public abstract class Program
     /// <summary>
     ///     Gets the configured subcommands for the application.
     /// </summary>
-    public static IEnumerable<string> ConfiguredSubCommands => _rootCommand.Subcommands.Select(s => s.Name);
+    public static IEnumerable<string> ConfiguredSubcommands => _rootCommand.Subcommands.Select(s => s.Name);
 }

--- a/src/Rankings/Program.cs
+++ b/src/Rankings/Program.cs
@@ -15,7 +15,7 @@ public abstract class Program
     /// <summary>
     ///     Represents the root command of the application.
     /// </summary>
-    private static readonly RootCommand RootCommand = new(Common.RootCommand_Description);
+    private static RootCommand _rootCommand;
     
     /// <summary>
     ///     The main entry point for the application.
@@ -23,15 +23,22 @@ public abstract class Program
     /// <param name="args">The command-line arguments.</param>
     public static void Main(string[] args)
     {
-        RootCommand.AddResultOption();
-        RootCommand.AddFileOption();
+        _rootCommand = new RootCommand(Common.RootCommand_Description);
+        _rootCommand.AddAppendFileSubCommand();
+        _rootCommand.AddAppendResultSubCommand();
+        _rootCommand.SetAction(_ => 0);
         
         // Automatically handles unhandled exceptions thrown during parsing or invocation.
-        RootCommand.Parse(args).Invoke();
+        _rootCommand.Parse(args).Invoke();
     }
     
     /// <summary>
     ///     Gets the configured options for the application.
     /// </summary>
-    public static IList<Option> ConfiguredOptions => RootCommand.Options;
+    public static IEnumerable<string> ConfiguredOptions => _rootCommand.Options.Select(o => o.Name);
+    
+    /// <summary>
+    ///     Gets the configured subcommands for the application.
+    /// </summary>
+    public static IEnumerable<string> ConfiguredSubCommands => _rootCommand.Subcommands.Select(s => s.Name);
 }

--- a/src/Rankings/Resources/Common.Designer.cs
+++ b/src/Rankings/Resources/Common.Designer.cs
@@ -60,6 +60,24 @@ namespace Rankings.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Appends a set of contest results from a file into the results file..
+        /// </summary>
+        internal static string AppendFile_Subcommand_Description {
+            get {
+                return ResourceManager.GetString("AppendFile_Subcommand_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Appends a single contest result to the results file..
+        /// </summary>
+        internal static string AppendResult_Subcommand_Description {
+            get {
+                return ResourceManager.GetString("AppendResult_Subcommand_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Value cannot contain a new line..
         /// </summary>
         internal static string CannotContainNewLine {
@@ -78,7 +96,7 @@ namespace Rankings.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Imports a set of results from the specified file into the results file. Each result must be in the form: &quot;&lt;CONTESTANT-1&gt; &lt;SCORE-1&gt;, &lt;CONTESTANT-2&gt; &lt;SCORE-2&gt;&quot;. See help for the --result option for further information..
+        ///   Looks up a localized string similar to Imports a set of contest results from the specified file into the results file. Each result must be in the form: &quot;&lt;CONTESTANT-1&gt; &lt;SCORE-1&gt;, &lt;CONTESTANT-2&gt; &lt;SCORE-2&gt;&quot;. See help for the append-result command for further information..
         /// </summary>
         internal static string FileOption_Description {
             get {
@@ -92,15 +110,6 @@ namespace Rankings.Resources {
         internal static string FileOption_Validation_FileDoesNotExist {
             get {
                 return ResourceManager.GetString("FileOption_Validation_FileDoesNotExist", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The file specified is empty..
-        /// </summary>
-        internal static string FileOption_Validation_FileIsEmpty {
-            get {
-                return ResourceManager.GetString("FileOption_Validation_FileIsEmpty", resourceCulture);
             }
         }
         

--- a/src/Rankings/Resources/Common.resx
+++ b/src/Rankings/Resources/Common.resx
@@ -49,12 +49,15 @@
         <value>A result must include scores for both contestants. Cannot find a score for contestant {0}.</value>
     </data>
     <data name="FileOption_Description" xml:space="preserve">
-        <value>Imports a set of results from the specified file into the results file. Each result must be in the form: "&lt;CONTESTANT-1&gt; &lt;SCORE-1&gt;, &lt;CONTESTANT-2&gt; &lt;SCORE-2&gt;". See help for the --result option for further information.</value>
+        <value>Imports a set of contest results from the specified file into the results file. Each result must be in the form: "&lt;CONTESTANT-1&gt; &lt;SCORE-1&gt;, &lt;CONTESTANT-2&gt; &lt;SCORE-2&gt;". See help for the append-result command for further information.</value>
     </data>
     <data name="FileOption_Validation_FileDoesNotExist" xml:space="preserve">
         <value>The file specified does not exist.</value>
     </data>
-    <data name="FileOption_Validation_FileIsEmpty" xml:space="preserve">
-        <value>The file specified is empty.</value>
+    <data name="AppendFile_Subcommand_Description" xml:space="preserve">
+        <value>Appends a set of contest results from a file into the results file.</value>
+    </data>
+    <data name="AppendResult_Subcommand_Description" xml:space="preserve">
+        <value>Appends a single contest result to the results file.</value>
     </data>
 </root>

--- a/test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs
+++ b/test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs
@@ -12,47 +12,47 @@ namespace Rankings.UnitTests.Extensions;
 public class RankingsRootCommandExtensionsTests
 {
     /// <summary>
-    ///     Tests that the <see cref="RankingsRootCommandExtensions.AddAppendFileSubCommand" /> method correctly adds
-    ///     the append-result subcommand to a root command.
+    ///     Tests that the <see cref="RankingsRootCommandExtensions.AddAppendFileSubcommand" /> method correctly adds
+    ///     the append-file subcommand to a root command.
     /// </summary>
     [Fact]
-    public void AddAppendFileSubCommand_AddsOptionToRootCommand()
+    public void AddAppendFileSubcommand_AddsOptionToRootCommand()
     {
         // Arrange
         var rootCommand = new RootCommand();
-        const string expectedSubCommandName = "append-file";
+        const string expectedSubcommandName = "append-file";
         
         // Act
-        rootCommand.AddAppendFileSubCommand();
+        rootCommand.AddAppendFileSubcommand();
         var subcommand = rootCommand
-            .Subcommands.FirstOrDefault(o => o.Name == expectedSubCommandName);
+            .Subcommands.FirstOrDefault(o => o.Name == expectedSubcommandName);
         
         // Assert
         Assert.NotNull(subcommand);
-        Assert.Equal(expectedSubCommandName, subcommand.Name);
+        Assert.Equal(expectedSubcommandName, subcommand.Name);
         Assert.NotNull(subcommand.Description);
         Assert.NotEmpty(subcommand.Description);
     }
     
     /// <summary>
-    ///     Tests that the <see cref="RankingsRootCommandExtensions.AddAppendResultSubCommand" /> method correctly adds the
-    ///     result option to a root command.
+    ///     Tests that the <see cref="RankingsRootCommandExtensions.AddAppendResultSubcommand" /> method correctly adds
+    ///     the result option to a root command.
     /// </summary>
     [Fact]
-    public void AddAppendResultSubCommand_AddsOptionToRootCommand()
+    public void AddAppendResultSubcommand_AddsOptionToRootCommand()
     {
         // Arrange
         var rootCommand = new RootCommand();
-        const string expectedSubCommandName = "append-result";
+        const string expectedSubcommandName = "append-result";
         
         // Act
-        rootCommand.AddAppendResultSubCommand();
+        rootCommand.AddAppendResultSubcommand();
         var subcommand = rootCommand
-            .Subcommands.FirstOrDefault(o => o.Name == expectedSubCommandName);
+            .Subcommands.FirstOrDefault(o => o.Name == expectedSubcommandName);
         
         // Assert
         Assert.NotNull(subcommand);
-        Assert.Equal(expectedSubCommandName, subcommand.Name);
+        Assert.Equal(expectedSubcommandName, subcommand.Name);
         Assert.NotNull(subcommand.Description);
         Assert.NotEmpty(subcommand.Description);
     }

--- a/test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs
+++ b/test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs
@@ -12,50 +12,48 @@ namespace Rankings.UnitTests.Extensions;
 public class RankingsRootCommandExtensionsTests
 {
     /// <summary>
-    ///     Tests that the <see cref="RankingsRootCommandExtensions.AddFileOption" /> method correctly adds the
-    ///     result option to a root command.
+    ///     Tests that the <see cref="RankingsRootCommandExtensions.AddAppendFileSubCommand" /> method correctly adds
+    ///     the append-result subcommand to a root command.
     /// </summary>
     [Fact]
-    public void AddFileOption_AddsOptionToRootCommand()
+    public void AddAppendFileSubCommand_AddsOptionToRootCommand()
     {
         // Arrange
         var rootCommand = new RootCommand();
-        const string expectedOptionName = "--file";
-        string[] expectedOptionAliases = ["-f"];
+        const string expectedSubCommandName = "append-file";
         
         // Act
-        rootCommand.AddFileOption();
-        var option = rootCommand.Options.FirstOrDefault(o => o.Name == expectedOptionName);
+        rootCommand.AddAppendFileSubCommand();
+        var subcommand = rootCommand
+            .Subcommands.FirstOrDefault(o => o.Name == expectedSubCommandName);
         
         // Assert
-        Assert.NotNull(option);
-        Assert.Equal(expectedOptionName, option.Name);
-        Assert.Equal(expectedOptionAliases, option.Aliases);
-        Assert.NotNull(option.Description);
-        Assert.NotEmpty(option.Description);
+        Assert.NotNull(subcommand);
+        Assert.Equal(expectedSubCommandName, subcommand.Name);
+        Assert.NotNull(subcommand.Description);
+        Assert.NotEmpty(subcommand.Description);
     }
     
     /// <summary>
-    ///     Tests that the <see cref="RankingsRootCommandExtensions.AddResultOption" /> method correctly adds the
+    ///     Tests that the <see cref="RankingsRootCommandExtensions.AddAppendResultSubCommand" /> method correctly adds the
     ///     result option to a root command.
     /// </summary>
     [Fact]
-    public void AddResultOption_AddsOptionToRootCommand()
+    public void AddAppendResultSubCommand_AddsOptionToRootCommand()
     {
         // Arrange
         var rootCommand = new RootCommand();
-        const string expectedOptionName = "--result";
-        string[] expectedOptionAliases = ["-r"];
+        const string expectedSubCommandName = "append-result";
         
         // Act
-        rootCommand.AddResultOption();
-        var option = rootCommand.Options.FirstOrDefault(o => o.Name == expectedOptionName);
+        rootCommand.AddAppendResultSubCommand();
+        var subcommand = rootCommand
+            .Subcommands.FirstOrDefault(o => o.Name == expectedSubCommandName);
         
         // Assert
-        Assert.NotNull(option);
-        Assert.Equal(expectedOptionName, option.Name);
-        Assert.Equal(expectedOptionAliases, option.Aliases);
-        Assert.NotNull(option.Description);
-        Assert.NotEmpty(option.Description);
+        Assert.NotNull(subcommand);
+        Assert.Equal(expectedSubCommandName, subcommand.Name);
+        Assert.NotNull(subcommand.Description);
+        Assert.NotEmpty(subcommand.Description);
     }
 }

--- a/test/Rankings.UnitTests/ProgramTests.cs
+++ b/test/Rankings.UnitTests/ProgramTests.cs
@@ -18,17 +18,36 @@ public class ProgramTests
         var expectedOptions = new[]
         {
             "--help",
-            "--version",
-            CommandLineOptions.ResultOption[0],
-            CommandLineOptions.FileOption[0]
+            "--version"
         };
 
         // Act
-        var optionsQuery = Program.ConfiguredOptions.Select(o => o.Name);
+        var optionsQuery = Program.ConfiguredOptions;
         var actualOptions = optionsQuery.ToArray();
 
         // Assert
         Assert.Equal(expectedOptions, actualOptions);
+    }
+    
+    /// <summary>
+    ///     Tests that the <see cref="Program.Main"/> method configures the root command with the expected subcommands.
+    /// </summary>
+    [Fact]
+    public void Main_ConfiguresRootCommandWithExpectedSubCommands()
+    {
+        // Arrange
+        var expectedSubCommands = new[]
+        {
+            "append-file",
+            "append-result"
+        };
+
+        // Act
+        var subcommandsQuery = Program.ConfiguredSubCommands;
+        var actualSubCommands = subcommandsQuery.ToArray();
+
+        // Assert
+        Assert.Equal(expectedSubCommands, actualSubCommands);
     }
     
     /// <summary>

--- a/test/Rankings.UnitTests/ProgramTests.cs
+++ b/test/Rankings.UnitTests/ProgramTests.cs
@@ -33,21 +33,21 @@ public class ProgramTests
     ///     Tests that the <see cref="Program.Main"/> method configures the root command with the expected subcommands.
     /// </summary>
     [Fact]
-    public void Main_ConfiguresRootCommandWithExpectedSubCommands()
+    public void Main_ConfiguresRootCommandWithExpectedSubcommands()
     {
         // Arrange
-        var expectedSubCommands = new[]
+        var expectedSubcommands = new[]
         {
             "append-file",
             "append-result"
         };
 
         // Act
-        var subcommandsQuery = Program.ConfiguredSubCommands;
-        var actualSubCommands = subcommandsQuery.ToArray();
+        var subcommandsQuery = Program.ConfiguredSubcommands;
+        var actualSubcommands = subcommandsQuery.ToArray();
 
         // Assert
-        Assert.Equal(expectedSubCommands, actualSubCommands);
+        Assert.Equal(expectedSubcommands, actualSubcommands);
     }
     
     /// <summary>

--- a/test/Rankings.UnitTests/Validators/FileValidatorTests.cs
+++ b/test/Rankings.UnitTests/Validators/FileValidatorTests.cs
@@ -24,7 +24,7 @@ public class FileValidatorTests
     {
         // Arrange
         var rootCommand = new RootCommand();
-        rootCommand.AddAppendFileSubCommand();
+        rootCommand.AddAppendFileSubcommand();
 
         // Act
         var parseResult = rootCommand.Parse(input);

--- a/test/Rankings.UnitTests/Validators/FileValidatorTests.cs
+++ b/test/Rankings.UnitTests/Validators/FileValidatorTests.cs
@@ -18,13 +18,13 @@ public class FileValidatorTests
     /// <param name="input">The input string to validate.</param>
     /// <param name="expected">The expected error message.</param>
     [Theory]
-    [InlineData("--file", "Required argument missing for option: '--file'.")]
-    [InlineData("--file \"none-existent.txt\"", "The file specified does not exist.")]
+    [InlineData("append-file --file", "Required argument missing for option: '--file'.")]
+    [InlineData("append-file --file \"none-existent.txt\"", "The file specified does not exist.")]
     public void Validate_WithError_AddsError(string input, string expected)
     {
         // Arrange
         var rootCommand = new RootCommand();
-        rootCommand.AddFileOption();
+        rootCommand.AddAppendFileSubCommand();
 
         // Act
         var parseResult = rootCommand.Parse(input);

--- a/test/Rankings.UnitTests/Validators/ResultValidatorTests.cs
+++ b/test/Rankings.UnitTests/Validators/ResultValidatorTests.cs
@@ -19,45 +19,45 @@ public class ResultValidatorTests
     /// <param name="input">The input string to validate.</param>
     /// <param name="expected">The expected error message.</param>
     [Theory]
-    [InlineData("--result", "Required argument missing for option: '--result'.")]
+    [InlineData("append-result --result", "Required argument missing for option: '--result'.")]
     [InlineData(
-        "--result \"1\n2\"",
+        "append-result --result \"1\n2\"",
         "A result must not contain any line breaks, it must be a single line.")]
     [InlineData(
-        "--result \"1\r2\"",
+        "append-result --result \"1\r2\"",
         "A result must not contain any line breaks, it must be a single line.")]
     [InlineData(
-        "--result \"1\r\n2\"",
+        "append-result --result \"1\r\n2\"",
         "A result must not contain any line breaks, it must be a single line.")]
     [InlineData(
-        $"--result \"1{ResultParser.ContestantResultSeparator}2{ResultParser.ContestantResultSeparator}3\"",
+        $"append-result --result \"1{ResultParser.ContestantResultSeparator}2{ResultParser.ContestantResultSeparator}3\"",
         $"A result can only contain one {ResultParser.ContestantResultSeparator} symbol.")]
     [InlineData(
-        "--result \"12345\"",
+        "append-result --result \"12345\"",
         $"A result must be separated into two parts by the {ResultParser.ContestantResultSeparator} symbol; one part for each contestant's name and score.")]
     [InlineData(
-        $"--result \"{ResultParser.ContestantResultSeparator} Bob 20\"",
+        $"append-result --result \"{ResultParser.ContestantResultSeparator} Bob 20\"",
         "A result must include the results for both contestants. Cannot find a result for contestant 1.")]
     [InlineData(
-        $"--result \"Alice 10{ResultParser.ContestantResultSeparator}\"",
+        $"append-result --result \"Alice 10{ResultParser.ContestantResultSeparator}\"",
         "A result must include the results for both contestants. Cannot find a result for contestant 2.")]
     [InlineData(
-        $"--result \"10{ResultParser.ContestantResultSeparator} Bob 20\"",
+        $"append-result --result \"10{ResultParser.ContestantResultSeparator} Bob 20\"",
         "A result must include names for both contestants. Cannot find a name for contestant 1.")]
     [InlineData(
-        $"--result \"Alice{ResultParser.ContestantResultSeparator} Bob 20\"",
+        $"append-result --result \"Alice{ResultParser.ContestantResultSeparator} Bob 20\"",
         "A result must include scores for both contestants. Cannot find a score for contestant 1.")]
     [InlineData(
-        $"--result \"Alice 10{ResultParser.ContestantResultSeparator}20\"",
+        $"append-result --result \"Alice 10{ResultParser.ContestantResultSeparator}20\"",
         "A result must include names for both contestants. Cannot find a name for contestant 2.")]
     [InlineData(
-        $"--result \"Alice 10{ResultParser.ContestantResultSeparator} Bob\"",
+        $"append-result --result \"Alice 10{ResultParser.ContestantResultSeparator} Bob\"",
         "A result must include scores for both contestants. Cannot find a score for contestant 2.")]
     public void Validate_WithError_AddsError(string input, string expected)
     {
         // Arrange
         var rootCommand = new RootCommand();
-        rootCommand.AddResultOption();
+        rootCommand.AddAppendResultSubCommand();
 
         // Act
         var parseResult = rootCommand.Parse(input);

--- a/test/Rankings.UnitTests/Validators/ResultValidatorTests.cs
+++ b/test/Rankings.UnitTests/Validators/ResultValidatorTests.cs
@@ -57,7 +57,7 @@ public class ResultValidatorTests
     {
         // Arrange
         var rootCommand = new RootCommand();
-        rootCommand.AddAppendResultSubCommand();
+        rootCommand.AddAppendResultSubcommand();
 
         // Act
         var parseResult = rootCommand.Parse(input);


### PR DESCRIPTION
This pull request refactors the command-line interface of the Rankings application to use explicit subcommands (`append-file` and `append-result`) instead of options at the root level. The changes improve clarity, organization, and testability of the CLI, and update related documentation, resource strings, and tests to match the new structure.

**Command-line interface refactor:**

* Introduced a new `CommandLineSubCommands` record to define the `append-file` and `append-result` subcommands. (`src/Rankings/CommandLineSubCommands.cs`)
* Replaced root-level options with subcommands in `RankingsRootCommandExtensions`, adding methods to attach the `append-file` and `append-result` subcommands to the root command, each with their own option(s) and description. (`src/Rankings/Extensions/RankingsRootCommandExtensions.cs`)
* Updated `Program.Main` to configure the root command with the new subcommands, and exposed lists of configured options and subcommands for testing. (`src/Rankings/Program.cs`)

**Localization and resource updates:**

* Added new resource strings for subcommand descriptions and updated existing descriptions to reference the new subcommands instead of options. Removed unused resource for empty file validation. (`src/Rankings/Resources/Common.Designer.cs`, `src/Rankings/Resources/Common.resx`)

**Unit test updates:**

* Refactored extension and validator tests to use and verify the new subcommand structure instead of root-level options. (`test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs`, `test/Rankings.UnitTests/Validators/FileValidatorTests.cs`, `test/Rankings.UnitTests/Validators/ResultValidatorTests.cs`)
* Updated `ProgramTests` to check for the presence of the new subcommands in the root command configuration. (`test/Rankings.UnitTests/ProgramTests.cs`)