### PR TITLE
feat: Add contest results processing service and related components.

### DIFF
--- a/src/Rankings/Parsers/ContestResult.cs
+++ b/src/Rankings/Parsers/ContestResult.cs
@@ -1,0 +1,40 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+using System.Diagnostics;
+
+namespace Rankings.Parsers;
+
+/// <summary>
+///     Represents a contest result.
+/// </summary>
+[DebuggerDisplay("{" + nameof(ToString) + "()}")]
+public class ContestResult
+{
+    /// <summary>
+    ///     Gets the first contestant's name, if any.
+    /// </summary>
+    public string Contestant1Name { get; set; } = string.Empty;
+    
+    /// <summary>
+    ///     Gets the first contestant's score, if any.
+    /// </summary>
+    public ushort Contestant1Score { get; set; }
+    
+    /// <summary>
+    ///     Gets the second contestant's name, if any.
+    /// </summary>
+    public string Contestant2Name { get; set; } = string.Empty;
+    
+    /// <summary>
+    ///     Gets the second contestant's score, if any.
+    /// </summary>
+    public ushort Contestant2Score { get; set; }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return
+            $"{Contestant1Name} {Contestant1Score}{ContestResultParser.ContestantResultSeparator} {Contestant2Name} {Contestant2Score}";
+    }
+}

--- a/src/Rankings/Program.cs
+++ b/src/Rankings/Program.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using Microsoft.Extensions.DependencyInjection;
 using Rankings.Extensions;
 using Rankings.Resources;
+using Rankings.Services;
 using Rankings.Storage;
 
 namespace Rankings;
@@ -27,6 +28,12 @@ public abstract class Program
     {
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddScoped<IStorageFactory, StorageFactory>();
+        serviceCollection.AddScoped<IContestResultsProcessor, ContestResultsProcessor>();
+
+        serviceCollection.Configure<ContestResultsProcessorOptions>(options =>
+        {
+            options.FilePath = "contest-results.jsonl";
+        });
         
         var serviceProvider = serviceCollection.BuildServiceProvider();
         

--- a/src/Rankings/Rankings.csproj
+++ b/src/Rankings/Rankings.csproj
@@ -36,11 +36,8 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-rc.1.25451.107" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Services\" />
     </ItemGroup>
 
 </Project>

--- a/src/Rankings/Resources/Common.Designer.cs
+++ b/src/Rankings/Resources/Common.Designer.cs
@@ -87,6 +87,105 @@ namespace Rankings.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The file specified cannot be accessed. The file name and path may be incorrect, the file may not be accessible, or the file may not exist..
+        /// </summary>
+        internal static string CommonAppendFile_Subcommand_FileNotAccessible {
+            get {
+                return ResourceManager.GetString("CommonAppendFile_Subcommand_FileNotAccessible", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot generate a valid contest result from invalid input..
+        /// </summary>
+        internal static string ContestResultParser_Validation_InvalidStateForGeneration {
+            get {
+                return ResourceManager.GetString("ContestResultParser_Validation_InvalidStateForGeneration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A result must be separated into two parts by the {0} symbol; one part for each contestant&apos;s name and score..
+        /// </summary>
+        internal static string ContestResultParser_Validation_MissingContestantResultSeparator {
+            get {
+                return ResourceManager.GetString("ContestResultParser_Validation_MissingContestantResultSeparator", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A result can only contain one {0} symbol..
+        /// </summary>
+        internal static string ContestResultParser_Validation_MultipleContestantResultSeparators {
+            get {
+                return ResourceManager.GetString("ContestResultParser_Validation_MultipleContestantResultSeparators", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A result must not contain any line breaks, it must be a single line..
+        /// </summary>
+        internal static string ContestResultParser_Validation_NewLineWithinContestantResult {
+            get {
+                return ResourceManager.GetString("ContestResultParser_Validation_NewLineWithinContestantResult", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A result must include names for both contestants. Cannot find a name for contestant {0}..
+        /// </summary>
+        internal static string ContestResultParser_Validation_NoContestantName {
+            get {
+                return ResourceManager.GetString("ContestResultParser_Validation_NoContestantName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A result must include the results for both contestants. Cannot find a result for contestant {0}..
+        /// </summary>
+        internal static string ContestResultParser_Validation_NoContestantResult {
+            get {
+                return ResourceManager.GetString("ContestResultParser_Validation_NoContestantResult", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A result must include scores for both contestants. Cannot find a score for contestant {0}..
+        /// </summary>
+        internal static string ContestResultParser_Validation_NoContestantScore {
+            get {
+                return ResourceManager.GetString("ContestResultParser_Validation_NoContestantScore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fatal error: The contest results processor is not registered..
+        /// </summary>
+        internal static string ContestResultsProcessor_NotRegistered {
+            get {
+                return ResourceManager.GetString("ContestResultsProcessor_NotRegistered", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Success: Added {0} contest result(s) to the contest results store. Rerun the command without any arguments to see the rankings latest table..
+        /// </summary>
+        internal static string ContestResultsProcessor_Processing_Success {
+            get {
+                return ResourceManager.GetString("ContestResultsProcessor_Processing_Success", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error in contestant result {0}: .
+        /// </summary>
+        internal static string ContestResultsProcessor_Validation_ParsingError {
+            get {
+                return ResourceManager.GetString("ContestResultsProcessor_Validation_ParsingError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Value cannot be empty or white-space..
         /// </summary>
         internal static string EmptyOrWhiteSpace {
@@ -123,7 +222,7 @@ namespace Rankings.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The file name is missing or empty and is invalid..
+        ///   Looks up a localized string similar to The file name is missing or empty..
         /// </summary>
         internal static string FileOption_Validation_MissingFileName {
             get {
@@ -141,65 +240,20 @@ namespace Rankings.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A result must be separated into two parts by the {0} symbol; one part for each contestant&apos;s name and score..
-        /// </summary>
-        internal static string ResultOption_Validation_MissingContestantResultSeparator {
-            get {
-                return ResourceManager.GetString("ResultOption_Validation_MissingContestantResultSeparator", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A result can only contain one {0} symbol..
-        /// </summary>
-        internal static string ResultOption_Validation_MultipleContestantResultSeparators {
-            get {
-                return ResourceManager.GetString("ResultOption_Validation_MultipleContestantResultSeparators", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A result must not contain any line breaks, it must be a single line..
-        /// </summary>
-        internal static string ResultOption_Validation_NewLineWithinContestantResult {
-            get {
-                return ResourceManager.GetString("ResultOption_Validation_NewLineWithinContestantResult", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A result must include names for both contestants. Cannot find a name for contestant {0}..
-        /// </summary>
-        internal static string ResultOption_Validation_NoContestantName {
-            get {
-                return ResourceManager.GetString("ResultOption_Validation_NoContestantName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A result must include the results for both contestants. Cannot find a result for contestant {0}..
-        /// </summary>
-        internal static string ResultOption_Validation_NoContestantResult {
-            get {
-                return ResourceManager.GetString("ResultOption_Validation_NoContestantResult", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A result must include scores for both contestants. Cannot find a score for contestant {0}..
-        /// </summary>
-        internal static string ResultOption_Validation_NoContestantScore {
-            get {
-                return ResourceManager.GetString("ResultOption_Validation_NoContestantScore", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Generate a ranking table..
         /// </summary>
         internal static string RootCommand_Description {
             get {
                 return ResourceManager.GetString("RootCommand_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fatal error: The storage factory is not registered..
+        /// </summary>
+        internal static string StorageFactory_NotRegistered {
+            get {
+                return ResourceManager.GetString("StorageFactory_NotRegistered", resourceCulture);
             }
         }
     }

--- a/src/Rankings/Resources/Common.resx
+++ b/src/Rankings/Resources/Common.resx
@@ -24,10 +24,10 @@
     <data name="ResultOption_Description" xml:space="preserve">
         <value>Adds a single contest result to the results file. A result must be in the form: "&lt;CONTESTANT-1&gt; &lt;SCORE-1&gt;, &lt;CONTESTANT-2&gt; &lt;SCORE-2&gt;". Replace &lt;CONTESTANT-n&gt; with the contestants' names such as, Team One, Team Two, etc. Names cannot start with - or --, and they cannot include the {0} symbol. Scores must be non-negative, whole numbers without any separator symbols, which means for example that 1000 is appropriate but 1,000 is not. Example: rankings -r "My Team 1{0} Other Team 0"</value>
     </data>
-    <data name="ResultOption_Validation_MissingContestantResultSeparator" xml:space="preserve">
+    <data name="ContestResultParser_Validation_MissingContestantResultSeparator" xml:space="preserve">
         <value>A result must be separated into two parts by the {0} symbol; one part for each contestant's name and score.</value>
     </data>
-    <data name="ResultOption_Validation_MultipleContestantResultSeparators" xml:space="preserve">
+    <data name="ContestResultParser_Validation_MultipleContestantResultSeparators" xml:space="preserve">
         <value>A result can only contain one {0} symbol.</value>
     </data>
     <data name="EmptyOrWhiteSpace" xml:space="preserve">
@@ -36,16 +36,16 @@
     <data name="CannotContainNewLine" xml:space="preserve">
         <value>Value cannot contain a new line.</value>
     </data>
-    <data name="ResultOption_Validation_NewLineWithinContestantResult" xml:space="preserve">
+    <data name="ContestResultParser_Validation_NewLineWithinContestantResult" xml:space="preserve">
         <value>A result must not contain any line breaks, it must be a single line.</value>
     </data>
-    <data name="ResultOption_Validation_NoContestantResult" xml:space="preserve">
+    <data name="ContestResultParser_Validation_NoContestantResult" xml:space="preserve">
         <value>A result must include the results for both contestants. Cannot find a result for contestant {0}.</value>
     </data>
-    <data name="ResultOption_Validation_NoContestantName" xml:space="preserve">
+    <data name="ContestResultParser_Validation_NoContestantName" xml:space="preserve">
         <value>A result must include names for both contestants. Cannot find a name for contestant {0}.</value>
     </data>
-    <data name="ResultOption_Validation_NoContestantScore" xml:space="preserve">
+    <data name="ContestResultParser_Validation_NoContestantScore" xml:space="preserve">
         <value>A result must include scores for both contestants. Cannot find a score for contestant {0}.</value>
     </data>
     <data name="FileOption_Description" xml:space="preserve">
@@ -64,6 +64,24 @@
         <value>The directory (folder) name contains invalid characters and is invalid.</value>
     </data>
     <data name="FileOption_Validation_MissingFileName" xml:space="preserve">
-        <value>The file name is missing or empty and is invalid.</value>
+        <value>The file name is missing or empty.</value>
+    </data>
+    <data name="StorageFactory_NotRegistered" xml:space="preserve">
+        <value>Fatal error: The storage factory is not registered.</value>
+    </data>
+    <data name="CommonAppendFile_Subcommand_FileNotAccessible" xml:space="preserve">
+        <value>The file specified cannot be accessed. The file name and path may be incorrect, the file may not be accessible, or the file may not exist.</value>
+    </data>
+    <data name="ContestResultsProcessor_NotRegistered" xml:space="preserve">
+        <value>Fatal error: The contest results processor is not registered.</value>
+    </data>
+    <data name="ContestResultsProcessor_Validation_ParsingError" xml:space="preserve">
+        <value>Error in contestant result {0}: </value>
+    </data>
+    <data name="ContestResultParser_Validation_InvalidStateForGeneration" xml:space="preserve">
+        <value>Cannot generate a valid contest result from invalid input.</value>
+    </data>
+    <data name="ContestResultsProcessor_Processing_Success" xml:space="preserve">
+        <value>Success: Added {0} contest result(s) to the contest results store. Rerun the command without any arguments to see the rankings latest table.</value>
     </data>
 </root>

--- a/src/Rankings/Services/ContestResultsProcessor.cs
+++ b/src/Rankings/Services/ContestResultsProcessor.cs
@@ -1,0 +1,72 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Rankings.Parsers;
+using Rankings.Resources;
+using Rankings.Storage;
+
+namespace Rankings.Services;
+
+/// <inheritdoc />
+public class ContestResultsProcessor : IContestResultsProcessor
+{
+    /// <summary>
+    ///     The options for the contest results processor.
+    /// </summary>
+    private readonly IOptions<ContestResultsProcessorOptions> _options;
+    
+    /// <summary>
+    ///     The storage factory used to create storage instances.
+    /// </summary>
+    private readonly IStorageFactory _storageFactory;
+    
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ContestResultsProcessor"/> class.
+    /// </summary>
+    /// <param name="options">The options for the contest results processor.</param>
+    /// <param name="storageFactory">The storage factory.</param>
+    public ContestResultsProcessor(IOptions<ContestResultsProcessorOptions> options, IStorageFactory storageFactory)
+    {
+        _options = options;
+        _storageFactory = storageFactory;
+    }
+    
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">Thrown if any of the results are invalid.</exception>
+    public void Process(string[] contestResults)
+    {
+        var parsedResults = new List<ContestResultParser>();
+        ContestResultParser? error = null;
+        foreach (var contestantResult in contestResults)
+        {
+            var parser = new ContestResultParser(contestantResult);
+            if (!parser.IsValid)
+            {
+                error = parser;
+                break;
+            }
+            parsedResults.Add(parser);
+        }
+        
+        if (error != null)
+        {
+            Console.Error.Write(Common.ContestResultsProcessor_Validation_ParsingError, parsedResults.Count + 1);
+            throw new InvalidOperationException(error.GetNextError());
+        }
+
+        var store = _storageFactory.CreateFileStore(_options.Value.FilePath);
+        
+        if (!store.IsInitialized) store.Initialize();
+
+        var jsonLines = parsedResults
+            .Select(contestResult => JsonSerializer
+                .Serialize(contestResult.GetContestResult(), new JsonSerializerOptions()))
+            .ToArray();
+
+        store.AppendAllLines(jsonLines);
+        
+        Console.Write(Common.ContestResultsProcessor_Processing_Success, parsedResults.Count);
+    }
+}

--- a/src/Rankings/Services/ContestResultsProcessorOptions.cs
+++ b/src/Rankings/Services/ContestResultsProcessorOptions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Rankings.Services;
+
+/// <summary>
+///     Represents options for configuring the <see cref="ContestResultsProcessor"/>.
+/// </summary>
+[ExcludeFromCodeCoverage(Justification = "POCOs are not tested.")]
+[DebuggerDisplay("{" + nameof(FilePath) + "}", Name = nameof(FilePath))]
+public class ContestResultsProcessorOptions
+{
+    /// <summary>
+    ///     Gets or sets the file path where contest results are stored and retrieved after processing.
+    /// </summary>
+    public string FilePath { get; set; } = string.Empty;
+}

--- a/src/Rankings/Services/IContestResultsProcessor.cs
+++ b/src/Rankings/Services/IContestResultsProcessor.cs
@@ -1,0 +1,16 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+namespace Rankings.Services;
+
+/// <summary>
+///     Represents a service that processes contest results by parsing then storing them.
+/// </summary>
+public interface IContestResultsProcessor
+{
+    /// <summary>
+    ///     Processes the provided contest results.
+    /// </summary>
+    /// <param name="contestResults">The contest results to process.</param>
+    public void Process(string[] contestResults);
+}

--- a/src/Rankings/Storage/FileReadOnlyStore.cs
+++ b/src/Rankings/Storage/FileReadOnlyStore.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
 // Published under the MIT License.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Rankings.Storage;
@@ -8,6 +9,7 @@ namespace Rankings.Storage;
 /// <summary>
 ///     Represents a read only store of text data backed by an operating system file.
 /// </summary>
+[DebuggerDisplay("{" + nameof(FileInfo) + "}", Name = nameof(FileInfo))]
 public class FileReadOnlyStore : IReadOnlyStore
 {
     /// <summary>
@@ -56,8 +58,9 @@ public class FileReadOnlyStore : IReadOnlyStore
     /// <remarks>
     ///     Exceptions are not caught and bubble up to be handled by the caller, which facilitates testing.
     /// </remarks>
+    /// <exception cref="FileNotFoundException">Thrown if the backing file does not exist.</exception>
     [ExcludeFromCodeCoverage(Justification = "File IO is an OS concern.")]
-    public virtual string[] ReadAllLines()
+    public string[] ReadAllLines()
     {
         // Any exception thrown bubbles up to be handled by the caller.
         return !FileInfo.Exists

--- a/src/Rankings/Storage/FileStore.cs
+++ b/src/Rankings/Storage/FileStore.cs
@@ -27,7 +27,7 @@ public class FileStore : FileReadOnlyStore, IStore
     ///     Exceptions are not caught and bubble up to be handled by the caller, which facilitates testing.
     /// </remarks>
     [ExcludeFromCodeCoverage(Justification = "File IO is an OS concern.")]
-    public virtual void AppendAllLines(string[] lines)
+    public void AppendAllLines(string[] lines)
     {
         // Any exception thrown bubbles up to be handled by the caller.
         File.AppendAllLines(FileInfo.FullName, lines);

--- a/src/Rankings/Validators/FileValidator.cs
+++ b/src/Rankings/Validators/FileValidator.cs
@@ -30,7 +30,7 @@ public abstract class FileValidator
             var hasFilePath = !string.IsNullOrWhiteSpace(filePath);
             
             // Identify validation errors in the order they should be reported.
-            var validations = new List<(bool IsError, string ErrorMessage)>
+            var errors = new List<(bool IsError, string ErrorMessage)>
             {
                 (!hasFilePath, Common.FileOption_Validation_MissingFileName)
             };
@@ -42,7 +42,7 @@ public abstract class FileValidator
                 var hasFileName = !string.IsNullOrWhiteSpace(fileInfo.Name);
 
                 // Identify validation errors in the order they should be reported.
-                validations.AddRange(new List<(bool, string)>
+                errors.AddRange(new List<(bool, string)>
                 {
                     (!hasFileName, Common.FileOption_Validation_MissingFileName),
                     (hasFileName && fileInfo.Name.IndexOfAny(Path.GetInvalidFileNameChars()) != notFound,
@@ -52,11 +52,14 @@ public abstract class FileValidator
                 });
             }
 
-            foreach (var (isError, errorMessage) in validations)
+            var error = errors
+                .Where(e => e.IsError)
+                .Select(e => e.ErrorMessage)
+                .FirstOrDefault();
+            
+            if (!string.IsNullOrEmpty(error))
             {
-                if (!isError) continue;
-                result.AddError(errorMessage);
-                return;
+                result.AddError(error);
             }
         };
     }

--- a/src/Rankings/Validators/ResultValidator.cs
+++ b/src/Rankings/Validators/ResultValidator.cs
@@ -14,7 +14,7 @@ namespace Rankings.Validators;
 public abstract class ResultValidator
 {
     /// <summary>
-    ///     Ensures that the option result contains a valid contestant result.
+    ///     Ensures that the option result contains a valid contest result.
     /// </summary>
     /// <returns>An action that validates the option result.</returns>
     public static Action<OptionResult> Validate()
@@ -26,44 +26,18 @@ public abstract class ResultValidator
                 // The result should never be null.
                 Debug.Assert(result != null);
                 Debug.Assert(result.GetValueOrDefault<string>() != null);
-                var resultParser = new ResultParser(result.GetValueOrDefault<string>());
 
-                // Identify validation errors in the order they should be reported.
-                var validations = new List<(bool IsError, string ErrorMessage)>
+                var contestResultParser = new ContestResultParser(result.GetValueOrDefault<string>());
+                var error = contestResultParser.GetNextError();
+
+                if (!string.IsNullOrEmpty(error))
                 {
-                    (resultParser.HasMultipleContestantResultSeparators,
-                        string.Format(
-                            Common.ResultOption_Validation_MultipleContestantResultSeparators,
-                            ResultParser.ContestantResultSeparator)),
-                    (resultParser.IsMissingContestantResultSeparator,
-                        string.Format(
-                            Common.ResultOption_Validation_MissingContestantResultSeparator,
-                            ResultParser.ContestantResultSeparator)),
-                    (resultParser.HasNoContestant1Result,
-                        string.Format(Common.ResultOption_Validation_NoContestantResult, 1)),
-                    (resultParser.HasNoContestant2Result,
-                        string.Format(Common.ResultOption_Validation_NoContestantResult, 2)),
-                    (resultParser.HasNoContestant1Name,
-                        string.Format(Common.ResultOption_Validation_NoContestantName, 1)),
-                    (resultParser.HasNoContestant1Score,
-                        string.Format(Common.ResultOption_Validation_NoContestantScore, 1)),
-                    (resultParser.HasNoContestant2Name,
-                        string.Format(Common.ResultOption_Validation_NoContestantName, 2)),
-                    (resultParser.HasNoContestant2Score,
-                        string.Format(Common.ResultOption_Validation_NoContestantScore, 2))
-                };
-                
-                // Stop validation on the first error found, working from left to right.
-                foreach (var (isError, errorMessage) in validations)
-                {
-                    if (!isError) continue;
-                    result.AddError(errorMessage);
-                    return;
+                    result.AddError(error);
                 }
             }
             catch (ArgumentException)
             {
-                result.AddError(Common.ResultOption_Validation_NewLineWithinContestantResult);
+                result.AddError(Common.ContestResultParser_Validation_NewLineWithinContestantResult);
             }
         };
     }

--- a/test/Rankings.UnitTests/Parsers/ContestResultParserTests.cs
+++ b/test/Rankings.UnitTests/Parsers/ContestResultParserTests.cs
@@ -6,9 +6,9 @@ using Rankings.Parsers;
 namespace Rankings.UnitTests.Parsers;
 
 /// <summary>
-///     Unit tests for the <see cref="ResultParser" /> class.
+///     Unit tests for the <see cref="ContestResultParser" /> class.
 /// </summary>
-public class ResultParserTests
+public class ContestResultParserTests
 {
     /// <summary>
     ///     Tests that the constructor throws an <see cref="ArgumentException" /> when the input is empty.
@@ -25,7 +25,7 @@ public class ResultParserTests
     public void Ctor_WithEmptyInput_ThrowsArgumentException(string input)
     {
         // Act
-        var exception = Record.Exception(() => new ResultParser(input));
+        var exception = Record.Exception(() => new ContestResultParser(input));
         
         // Assert
         Assert.NotNull(exception);
@@ -47,91 +47,91 @@ public class ResultParserTests
     /// </remarks>
     [Theory]
     [InlineData(
-        $"{ResultParser.ContestantResultSeparator}",
+        $"{ContestResultParser.ContestantResultSeparator}",
         "",
         0,
         "",
         0)]
     [InlineData(
-        $"10{ResultParser.ContestantResultSeparator}",
+        $"10{ContestResultParser.ContestantResultSeparator}",
         "",
         10,
         "",
         0)]
     [InlineData(
-        $"{ResultParser.ContestantResultSeparator}10",
+        $"{ContestResultParser.ContestantResultSeparator}10",
         "",
         0,
         "",
         10)]
     [InlineData(
-        $"10{ResultParser.ContestantResultSeparator}10",
+        $"10{ContestResultParser.ContestantResultSeparator}10",
         "",
         10,
         "",
         10)]
     [InlineData(
-        $"Alice in Wonderland{ResultParser.ContestantResultSeparator}",
+        $"Alice in Wonderland{ContestResultParser.ContestantResultSeparator}",
         "Alice in Wonderland",
         0,
         "",
         0)]
     [InlineData(
-        $"{ResultParser.ContestantResultSeparator}Bob the Builder",
+        $"{ContestResultParser.ContestantResultSeparator}Bob the Builder",
         "",
         0,
         "Bob the Builder",
         0)]
     [InlineData(
-        $"Alice in Wonderland{ResultParser.ContestantResultSeparator}Bob the Builder",
+        $"Alice in Wonderland{ContestResultParser.ContestantResultSeparator}Bob the Builder",
         "Alice in Wonderland",
         0,
         "Bob the Builder",
         0)]
     [InlineData(
-        $"Alice in Wonderland{ResultParser.ContestantResultSeparator}10",
+        $"Alice in Wonderland{ContestResultParser.ContestantResultSeparator}10",
         "Alice in Wonderland",
         0,
         "",
         10)]
     [InlineData(
-        $"10{ResultParser.ContestantResultSeparator}Bob the Builder",
+        $"10{ContestResultParser.ContestantResultSeparator}Bob the Builder",
         "",
         10,
         "Bob the Builder",
         0)]
     [InlineData(
-        $"-1{ResultParser.ContestantResultSeparator}",
+        $"-1{ContestResultParser.ContestantResultSeparator}",
         "",
         0,
         "",
         0)]
     [InlineData(
-        $"{ResultParser.ContestantResultSeparator}-1",
+        $"{ContestResultParser.ContestantResultSeparator}-1",
         "",
         0,
         "",
         0)]
     [InlineData(
-        $"Alice in Wonderland-1{ResultParser.ContestantResultSeparator}",
+        $"Alice in Wonderland-1{ContestResultParser.ContestantResultSeparator}",
         "Alice in Wonderland-1",
         0,
         "",
         0)]
     [InlineData(
-        $"{ResultParser.ContestantResultSeparator}Bob the Builder-1",
+        $"{ContestResultParser.ContestantResultSeparator}Bob the Builder-1",
         "",
         0,
         "Bob the Builder-1",
         0)]
     [InlineData(
-        $"-1Alice in Wonderland{ResultParser.ContestantResultSeparator}",
+        $"-1Alice in Wonderland{ContestResultParser.ContestantResultSeparator}",
         "-1Alice in Wonderland",
         0,
         "",
         0)]
     [InlineData(
-        $"{ResultParser.ContestantResultSeparator}-1Bob the Builder",
+        $"{ContestResultParser.ContestantResultSeparator}-1Bob the Builder",
         "",
         0,
         "-1Bob the Builder",
@@ -144,14 +144,16 @@ public class ResultParserTests
         ushort expectedContestant2Score)
     {
         // Arrange
-        var contestantResults = input.Split(ResultParser.ContestantResultSeparator);
-        var hasNoContestant1ResultExpected = string.IsNullOrWhiteSpace(contestantResults[0]);
-        var hasNoContestant2ResultExpected = string.IsNullOrWhiteSpace(contestantResults[1]);
+        var results = input.Split(ContestResultParser.ContestantResultSeparator);
+        var hasNoContestant1ResultExpected = string.IsNullOrWhiteSpace(results[0]);
+        var hasNoContestant2ResultExpected = string.IsNullOrWhiteSpace(results[1]);
 
         // Act
-        var parser = new ResultParser(input);
+        var parser = new ContestResultParser(input);
 
         // Assert
+        Assert.False(parser.IsValid);
+        
         Assert.False(parser.HasMultipleContestantResultSeparators);
         Assert.False(parser.IsMissingContestantResultSeparator);
 
@@ -190,7 +192,7 @@ public class ResultParserTests
     public void Ctor_WithNewLineInInput_ThrowsArgumentException(string input)
     {
         // Act
-        var exception = Record.Exception(() => new ResultParser(input));
+        var exception = Record.Exception(() => new ContestResultParser(input));
         
         // Assert
         Assert.NotNull(exception);
@@ -209,7 +211,7 @@ public class ResultParserTests
         string input = null!;
         
         // Act
-        var exception = Record.Exception(() => new ResultParser(input));
+        var exception = Record.Exception(() => new ContestResultParser(input));
         
         // Assert
         Assert.NotNull(exception);
@@ -218,7 +220,7 @@ public class ResultParserTests
     }
     
     /// <summary>
-    ///     Tests that the constructor sets <see cref="ResultParser.IsMissingContestantResultSeparator" />
+    ///     Tests that the constructor sets <see cref="ContestResultParser.IsMissingContestantResultSeparator" />
     ///     to <c>true</c> when the input is missing the contestant result separator, regardless of spacing.
     /// </summary>
     /// <param name="input"></param>
@@ -229,9 +231,11 @@ public class ResultParserTests
     public void Ctor_WithMissingContestantResultSeparator_SetsIsMissingContestantResultSeparatorToTrue(string input)
     {
         // Act
-        var parser = new ResultParser(input);
+        var parser = new ContestResultParser(input);
         
         // Assert
+        Assert.False(parser.IsValid);
+        
         Assert.True(parser.IsMissingContestantResultSeparator);
         
         Assert.True(parser.HasNoContestant1Name);
@@ -250,30 +254,32 @@ public class ResultParserTests
     }
     
     /// <summary>
-    ///     Tests that the constructor sets <see cref="ResultParser.HasMultipleContestantResultSeparators" />
+    ///     Tests that the constructor sets <see cref="ContestResultParser.HasMultipleContestantResultSeparators" />
     ///     to <c>true</c> when the input contains multiple contestant result separators, regardless of spacing.
     /// </summary>
     /// <param name="input">The input to parse.</param>
     [Theory]
     [InlineData(
-        $"Alice 10{ResultParser.ContestantResultSeparator} Bob 20{ResultParser.ContestantResultSeparator} Charlie 30")]
+        $"Alice 10{ContestResultParser.ContestantResultSeparator} Bob 20{ContestResultParser.ContestantResultSeparator} Charlie 30")]
     [InlineData(
-        $"Alice 10 {ResultParser.ContestantResultSeparator} Bob 20 {ResultParser.ContestantResultSeparator} Charlie 30")]
+        $"Alice 10 {ContestResultParser.ContestantResultSeparator} Bob 20 {ContestResultParser.ContestantResultSeparator} Charlie 30")]
     [InlineData(
-        $"Alice 10 {ResultParser.ContestantResultSeparator}Bob 20 {ResultParser.ContestantResultSeparator}Charlie 30")]
+        $"Alice 10 {ContestResultParser.ContestantResultSeparator}Bob 20 {ContestResultParser.ContestantResultSeparator}Charlie 30")]
     [InlineData(
-        $"Alice 10{ResultParser.ContestantResultSeparator} Bob 20 {ResultParser.ContestantResultSeparator}Charlie 30")]
+        $"Alice 10{ContestResultParser.ContestantResultSeparator} Bob 20 {ContestResultParser.ContestantResultSeparator}Charlie 30")]
     [InlineData(
-        $"Alice 10 {ResultParser.ContestantResultSeparator} Bob 20{ResultParser.ContestantResultSeparator} Charlie 30")]
+        $"Alice 10 {ContestResultParser.ContestantResultSeparator} Bob 20{ContestResultParser.ContestantResultSeparator} Charlie 30")]
     [InlineData(
-        $"Alice 10{ResultParser.ContestantResultSeparator}Bob 20{ResultParser.ContestantResultSeparator}Charlie 30")]
+        $"Alice 10{ContestResultParser.ContestantResultSeparator}Bob 20{ContestResultParser.ContestantResultSeparator}Charlie 30")]
     public void Ctor_WithMultipleContestantResultSeparators_SetsHasMultipleContestantResultSeparatorsToTrue(
         string input)
     {
         // Act
-        var parser = new ResultParser(input);
+        var parser = new ContestResultParser(input);
         
         // Assert
+        Assert.False(parser.IsValid);
+        
         Assert.True(parser.HasMultipleContestantResultSeparators);
         Assert.False(parser.IsMissingContestantResultSeparator);
         
@@ -293,7 +299,7 @@ public class ResultParserTests
     }
 
     /// <summary>
-    ///     Tests that the constructor sets <see cref="ResultParser.HasNoContestant1Name" />
+    ///     Tests that the constructor sets <see cref="ContestResultParser.HasNoContestant1Name" />
     ///     to <c>true</c> when the input is missing the first contestant name, regardless of spacing.
     /// </summary>
     /// <param name="input">The input to parse.</param>
@@ -303,37 +309,37 @@ public class ResultParserTests
     /// <param name="expectedContestant2Score">The expected score of the second contestant.</param>
     [Theory]
     [InlineData(
-        $"10{ResultParser.ContestantResultSeparator} Bob 20",
+        $"10{ContestResultParser.ContestantResultSeparator} Bob 20",
         "",
         10,
         "Bob",
         20)]
     [InlineData(
-        $" 10{ResultParser.ContestantResultSeparator} Bob 20",
+        $" 10{ContestResultParser.ContestantResultSeparator} Bob 20",
         "",
         10,
         "Bob",
         20)]
     [InlineData(
-        $"10{ResultParser.ContestantResultSeparator} Bob 20 ",
+        $"10{ContestResultParser.ContestantResultSeparator} Bob 20 ",
         "",
         10,
         "Bob",
         20)]
     [InlineData(
-        $" 10{ResultParser.ContestantResultSeparator} Bob 20 ",
+        $" 10{ContestResultParser.ContestantResultSeparator} Bob 20 ",
         "",
         10,
         "Bob",
         20)]
     [InlineData(
-        $"10{ResultParser.ContestantResultSeparator}\tBob 20",
+        $"10{ContestResultParser.ContestantResultSeparator}\tBob 20",
         "",
         10,
         "Bob",
         20)]
     [InlineData(
-        $" 10{ResultParser.ContestantResultSeparator}\tBob 20",
+        $" 10{ContestResultParser.ContestantResultSeparator}\tBob 20",
         "",
         10,
         "Bob",
@@ -346,9 +352,11 @@ public class ResultParserTests
         ushort expectedContestant2Score)
     {
         // Act
-        var parser = new ResultParser(input);
+        var parser = new ContestResultParser(input);
         
         // Assert
+        Assert.False(parser.IsValid);
+        
         Assert.False(parser.HasMultipleContestantResultSeparators);
         Assert.False(parser.IsMissingContestantResultSeparator);
         
@@ -368,7 +376,7 @@ public class ResultParserTests
     }
 
     /// <summary>
-    ///     Tests that the constructor sets <see cref="ResultParser.HasNoContestant1Result" />
+    ///     Tests that the constructor sets <see cref="ContestResultParser.HasNoContestant1Result" />
     ///     to <c>true</c> when the input is missing the first contestant result, regardless of spacing.
     /// </summary>
     /// <param name="input">The input to parse.</param>
@@ -376,27 +384,27 @@ public class ResultParserTests
     /// <param name="expectedContestant2Score">The expected score of the second contestant.</param>
     [Theory]
     [InlineData(
-        $"{ResultParser.ContestantResultSeparator} Bob 20",
+        $"{ContestResultParser.ContestantResultSeparator} Bob 20",
         "Bob",
         20)]
     [InlineData(
-        $" {ResultParser.ContestantResultSeparator} Bob 20",
+        $" {ContestResultParser.ContestantResultSeparator} Bob 20",
         "Bob",
         20)]
     [InlineData(
-        $"{ResultParser.ContestantResultSeparator} Bob 20 ",
+        $"{ContestResultParser.ContestantResultSeparator} Bob 20 ",
         "Bob",
         20)]
     [InlineData(
-        $" {ResultParser.ContestantResultSeparator} Bob 20 ",
+        $" {ContestResultParser.ContestantResultSeparator} Bob 20 ",
         "Bob",
         20)]
     [InlineData(
-        $" \t {ResultParser.ContestantResultSeparator} Bob 20 ",
+        $" \t {ContestResultParser.ContestantResultSeparator} Bob 20 ",
         "Bob",
         20)]
     [InlineData(
-        $" \t {ResultParser.ContestantResultSeparator} Bob 20 \t ",
+        $" \t {ContestResultParser.ContestantResultSeparator} Bob 20 \t ",
         "Bob",
         20)]
     public void Ctor_WithNoContestant1Result_SetsHasNoContestant1ResultToTrue(
@@ -405,9 +413,11 @@ public class ResultParserTests
         ushort expectedContestant2Score)
     {
         // Act
-        var parser = new ResultParser(input);
+        var parser = new ContestResultParser(input);
         
         // Assert
+        Assert.False(parser.IsValid);
+        
         Assert.False(parser.HasMultipleContestantResultSeparators);
         Assert.False(parser.IsMissingContestantResultSeparator);
         
@@ -427,7 +437,7 @@ public class ResultParserTests
     }
     
     /// <summary>
-    ///     Tests that the constructor sets <see cref="ResultParser.HasNoContestant1Score" />
+    ///     Tests that the constructor sets <see cref="ContestResultParser.HasNoContestant1Score" />
     ///     to <c>true</c> when the input is missing the first contestant score, regardless of spacing.
     /// </summary>
     /// <param name="input">The input to parse.</param>
@@ -437,37 +447,37 @@ public class ResultParserTests
     /// <param name="expectedContestant2Score">The expected score of the second contestant.</param>
     [Theory]
     [InlineData(
-        $"Alice{ResultParser.ContestantResultSeparator} Bob 20",
+        $"Alice{ContestResultParser.ContestantResultSeparator} Bob 20",
         "Alice",
         0,
         "Bob",
         20)]
     [InlineData(
-        $"Alice {ResultParser.ContestantResultSeparator} Bob 20",
+        $"Alice {ContestResultParser.ContestantResultSeparator} Bob 20",
         "Alice",
         0,
         "Bob",
         20)]
     [InlineData(
-        $"Alice{ResultParser.ContestantResultSeparator} Bob 20 ",
+        $"Alice{ContestResultParser.ContestantResultSeparator} Bob 20 ",
         "Alice",
         0,
         "Bob",
         20)]
     [InlineData(
-        $"Alice {ResultParser.ContestantResultSeparator} Bob 20 ",
+        $"Alice {ContestResultParser.ContestantResultSeparator} Bob 20 ",
         "Alice",
         0,
         "Bob",
         20)]
     [InlineData(
-        $"Alice{ResultParser.ContestantResultSeparator}\tBob 20",
+        $"Alice{ContestResultParser.ContestantResultSeparator}\tBob 20",
         "Alice",
         0,
         "Bob",
         20)]
     [InlineData(
-        $"Alice {ResultParser.ContestantResultSeparator}\tBob 20",
+        $"Alice {ContestResultParser.ContestantResultSeparator}\tBob 20",
         "Alice",
         0,
         "Bob",
@@ -480,9 +490,11 @@ public class ResultParserTests
         ushort expectedContestant2Score)
     {
         // Act
-        var parser = new ResultParser(input);
+        var parser = new ContestResultParser(input);
         
         // Assert
+        Assert.False(parser.IsValid);
+        
         Assert.False(parser.HasMultipleContestantResultSeparators);
         Assert.False(parser.IsMissingContestantResultSeparator);
         
@@ -502,7 +514,7 @@ public class ResultParserTests
     }
 
     /// <summary>
-    ///     Tests that the constructor sets <see cref="ResultParser.HasNoContestant2Name" />
+    ///     Tests that the constructor sets <see cref="ContestResultParser.HasNoContestant2Name" />
     ///     to <c>true</c> when the input is missing the second contestant name, regardless of spacing.
     /// </summary>
     /// <param name="input">The input to parse.</param>
@@ -512,37 +524,37 @@ public class ResultParserTests
     /// <param name="expectedContestant2Score">The expected score of the second contestant.</param>
     [Theory]
     [InlineData(
-        $"Alice 20{ResultParser.ContestantResultSeparator} 10",
+        $"Alice 20{ContestResultParser.ContestantResultSeparator} 10",
         "Alice",
         20,
         "",
         10)]
     [InlineData(
-        $"Alice 20 {ResultParser.ContestantResultSeparator} 10",
+        $"Alice 20 {ContestResultParser.ContestantResultSeparator} 10",
         "Alice",
         20,
         "",
         10)]
     [InlineData(
-        $"Alice 20{ResultParser.ContestantResultSeparator} 10 ",
+        $"Alice 20{ContestResultParser.ContestantResultSeparator} 10 ",
         "Alice",
         20,
         "",
         10)]
     [InlineData(
-        $"Alice 20 {ResultParser.ContestantResultSeparator} 10 ",
+        $"Alice 20 {ContestResultParser.ContestantResultSeparator} 10 ",
         "Alice",
         20,
         "",
         10)]
     [InlineData(
-        $"\tAlice 20{ResultParser.ContestantResultSeparator}10",
+        $"\tAlice 20{ContestResultParser.ContestantResultSeparator}10",
         "Alice",
         20,
         "",
         10)]
     [InlineData(
-        $"\tAlice 20 {ResultParser.ContestantResultSeparator} 10",
+        $"\tAlice 20 {ContestResultParser.ContestantResultSeparator} 10",
         "Alice",
         20,
         "",
@@ -555,9 +567,11 @@ public class ResultParserTests
         ushort expectedContestant2Score)
     {
         // Act
-        var parser = new ResultParser(input);
+        var parser = new ContestResultParser(input);
         
         // Assert
+        Assert.False(parser.IsValid);
+        
         Assert.False(parser.HasMultipleContestantResultSeparators);
         Assert.False(parser.IsMissingContestantResultSeparator);
         
@@ -577,7 +591,7 @@ public class ResultParserTests
     }
 
     /// <summary>
-    ///     Tests that the constructor sets <see cref="ResultParser.HasNoContestant2Result" />
+    ///     Tests that the constructor sets <see cref="ContestResultParser.HasNoContestant2Result" />
     ///     to <c>true</c> when the input is missing the second contestant result, regardless of spacing.
     /// </summary>
     /// <param name="input">The input to parse.</param>
@@ -585,26 +599,26 @@ public class ResultParserTests
     /// <param name="expectedContestant1Score">The expected score of the first contestant.</param>
     [Theory]
     [InlineData(
-        $"Alice 10{ResultParser.ContestantResultSeparator}",
+        $"Alice 10{ContestResultParser.ContestantResultSeparator}",
         "Alice",
         10)]
-    [InlineData($"Alice 10{ResultParser.ContestantResultSeparator} ",
-        "Alice",
-        10)]
-    [InlineData(
-        $"Alice 10 {ResultParser.ContestantResultSeparator}",
+    [InlineData($"Alice 10{ContestResultParser.ContestantResultSeparator} ",
         "Alice",
         10)]
     [InlineData(
-        $"Alice 10 {ResultParser.ContestantResultSeparator} ",
+        $"Alice 10 {ContestResultParser.ContestantResultSeparator}",
         "Alice",
         10)]
     [InlineData(
-        $"Alice 10 {ResultParser.ContestantResultSeparator}\t",
+        $"Alice 10 {ContestResultParser.ContestantResultSeparator} ",
         "Alice",
         10)]
     [InlineData(
-        $"Alice 10{ResultParser.ContestantResultSeparator}\t",
+        $"Alice 10 {ContestResultParser.ContestantResultSeparator}\t",
+        "Alice",
+        10)]
+    [InlineData(
+        $"Alice 10{ContestResultParser.ContestantResultSeparator}\t",
         "Alice",
         10)]
     public void Ctor_WithNoContestant2Result_SetsHasNoContestant2ResultToTrue(
@@ -613,9 +627,11 @@ public class ResultParserTests
         ushort expectedContestant1Score)
     {
         // Act
-        var parser = new ResultParser(input);
+        var parser = new ContestResultParser(input);
 
         // Assert
+        Assert.False(parser.IsValid);
+        
         Assert.False(parser.HasMultipleContestantResultSeparators);
         Assert.False(parser.IsMissingContestantResultSeparator);
         
@@ -635,7 +651,7 @@ public class ResultParserTests
     }
     
     /// <summary>
-    ///     Tests that the constructor sets <see cref="ResultParser.HasNoContestant2Score" />
+    ///     Tests that the constructor sets <see cref="ContestResultParser.HasNoContestant2Score" />
     ///     to <c>true</c> when the input is missing the second contestant score, regardless of spacing.
     /// </summary>
     /// <param name="input">The input to parse.</param>
@@ -645,37 +661,37 @@ public class ResultParserTests
     /// <param name="expectedContestant2Score">The expected score of the second contestant.</param>
     [Theory]
     [InlineData(
-        $"Alice 20{ResultParser.ContestantResultSeparator} Bob",
+        $"Alice 20{ContestResultParser.ContestantResultSeparator} Bob",
         "Alice",
         20,
         "Bob",
         0)]
     [InlineData(
-        $"Alice 20 {ResultParser.ContestantResultSeparator} Bob",
+        $"Alice 20 {ContestResultParser.ContestantResultSeparator} Bob",
         "Alice",
         20,
         "Bob",
         0)]
     [InlineData(
-        $"Alice 20{ResultParser.ContestantResultSeparator} Bob ",
+        $"Alice 20{ContestResultParser.ContestantResultSeparator} Bob ",
         "Alice",
         20,
         "Bob",
         0)]
     [InlineData(
-        $"Alice 20 {ResultParser.ContestantResultSeparator} Bob ",
+        $"Alice 20 {ContestResultParser.ContestantResultSeparator} Bob ",
         "Alice",
         20,
         "Bob",
         0)]
     [InlineData(
-        $"\tAlice 20{ResultParser.ContestantResultSeparator}Bob",
+        $"\tAlice 20{ContestResultParser.ContestantResultSeparator}Bob",
         "Alice",
         20,
         "Bob",
         0)]
     [InlineData(
-        $"\tAlice 20 {ResultParser.ContestantResultSeparator}Bob ",
+        $"\tAlice 20 {ContestResultParser.ContestantResultSeparator}Bob ",
         "Alice",
         20,
         "Bob",
@@ -688,9 +704,11 @@ public class ResultParserTests
         ushort expectedContestant2Score)
     {
         // Act
-        var parser = new ResultParser(input);
+        var parser = new ContestResultParser(input);
         
         // Assert
+        Assert.False(parser.IsValid);
+        
         Assert.False(parser.HasMultipleContestantResultSeparators);
         Assert.False(parser.IsMissingContestantResultSeparator);
         
@@ -719,19 +737,19 @@ public class ResultParserTests
     /// <param name="expectedContestant2Score">The expected score of the second contestant.</param>
     [Theory]
     [InlineData(
-        $"Alice 0{ResultParser.ContestantResultSeparator} Bob 0",
+        $"Alice 0{ContestResultParser.ContestantResultSeparator} Bob 0",
         "Alice",
         0,
         "Bob",
         0)]
     [InlineData(
-        $"Alice in Wonderland 0{ResultParser.ContestantResultSeparator} Bob the Builder 0",
+        $"Alice in Wonderland 0{ContestResultParser.ContestantResultSeparator} Bob the Builder 0",
         "Alice in Wonderland",
         0,
         "Bob the Builder",
         0)]
     [InlineData(
-        $"Awesome FC 22{ResultParser.ContestantResultSeparator} Boresome FC 11",
+        $"Awesome FC 22{ContestResultParser.ContestantResultSeparator} Boresome FC 11",
         "Awesome FC",
         22,
         "Boresome FC",
@@ -744,9 +762,11 @@ public class ResultParserTests
         ushort expectedContestant2Score)
     {
         // Act
-        var parser = new ResultParser(input);
+        var parser = new ContestResultParser(input);
         
         // Assert
+        Assert.True(parser.IsValid);
+        
         Assert.False(parser.HasMultipleContestantResultSeparators);
         Assert.False(parser.IsMissingContestantResultSeparator);
         
@@ -763,5 +783,103 @@ public class ResultParserTests
         
         Assert.Equal(expectedContestant2Name, parser.Contestant2Name);
         Assert.Equal(expectedContestant2Score, parser.Contestant2Score);
+    }
+
+    /// <summary>
+    ///     Tests that <see cref="ContestResultParser.GetContestResult" /> throws an
+    ///     <see cref="InvalidOperationException" /> when the input is invalid.
+    /// </summary>
+    [Fact]
+    public void GetContestResult_WithInvalidInput_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var parser = new ContestResultParser("Alice 10 Bob 20");
+        
+        // Act
+        var exception = Record.Exception(() => parser.GetContestResult());
+        
+        // Assert
+        Assert.NotNull(exception);
+        Assert.IsType<InvalidOperationException>(exception);
+        Assert.Equal("Cannot generate a valid contest result from invalid input.", exception.Message);
+    }
+
+    /// <summary>
+    ///     Tests that <see cref="ContestResultParser.GetContestResult" /> returns a valid
+    ///     <see cref="ContestResult" /> when the input is valid.
+    /// </summary>
+    [Fact]
+    public void GetContestResult_WithValidInput_ReturnsContestResult()
+    {
+        // Arrange
+        var parser = new ContestResultParser($"Alice 10{ContestResultParser.ContestantResultSeparator} Bob 20");
+        
+        // Act
+        var actual = parser.GetContestResult();
+        
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Equal("Alice", actual.Contestant1Name);
+        Assert.Equal(10, actual.Contestant1Score);
+        Assert.Equal("Bob", actual.Contestant2Name);
+        Assert.Equal(20, actual.Contestant2Score);
+    }
+    
+    /// <summary>
+    ///     Tests that <see cref="ContestResultParser.GetNextError" /> returns the correct error message for invalid input.
+    /// </summary>
+    /// <param name="input">The input string to validate.</param>
+    /// <param name="expected">The expected error message.</param>
+    [Theory]
+    [InlineData(
+        $"1{ContestResultParser.ContestantResultSeparator}2{ContestResultParser.ContestantResultSeparator}3",
+        $"A result can only contain one {ContestResultParser.ContestantResultSeparator} symbol.")]
+    [InlineData(
+        "12345",
+        $"A result must be separated into two parts by the {ContestResultParser.ContestantResultSeparator} symbol; one part for each contestant's name and score.")]
+    [InlineData(
+        $"{ContestResultParser.ContestantResultSeparator} Bob 20",
+        "A result must include the results for both contestants. Cannot find a result for contestant 1.")]
+    [InlineData(
+        $"Alice 10{ContestResultParser.ContestantResultSeparator}",
+        "A result must include the results for both contestants. Cannot find a result for contestant 2.")]
+    [InlineData(
+        $"10{ContestResultParser.ContestantResultSeparator} Bob 20",
+        "A result must include names for both contestants. Cannot find a name for contestant 1.")]
+    [InlineData(
+        $"Alice{ContestResultParser.ContestantResultSeparator} Bob 20",
+        "A result must include scores for both contestants. Cannot find a score for contestant 1.")]
+    [InlineData(
+        $"Alice 10{ContestResultParser.ContestantResultSeparator}20",
+        "A result must include names for both contestants. Cannot find a name for contestant 2.")]
+    [InlineData(
+        $"Alice 10{ContestResultParser.ContestantResultSeparator} Bob",
+        "A result must include scores for both contestants. Cannot find a score for contestant 2.")]
+    public void GetNextError_WithInvalid_ReturnsErrors(string input, string expected)
+    {
+        // Arrange
+        var parser = new ContestResultParser(input);
+        
+        // Act
+        var actual = parser.GetNextError();
+        
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    ///     Tests that <see cref="ContestResultParser.GetNextError" /> returns <c>null</c> for valid input.
+    /// </summary>
+    [Fact]
+    public void GetNextError_WithValidInput_ReturnsNull()
+    {
+        // Arrange
+        var parser = new ContestResultParser($"Alice 10{ContestResultParser.ContestantResultSeparator} Bob 20");
+        
+        // Act
+        var actual = parser.GetNextError();
+        
+        // Assert
+        Assert.Null(actual);
     }
 }

--- a/test/Rankings.UnitTests/Parsers/ContestResultTests.cs
+++ b/test/Rankings.UnitTests/Parsers/ContestResultTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+using Rankings.Parsers;
+
+namespace Rankings.UnitTests.Parsers;
+
+/// <summary>
+///     Unit tests for the <see cref="ContestResult"/> class.
+/// </summary>
+public class ContestResultTests
+{
+    /// <summary>
+    ///     Tests that <see cref="ContestResult.ToString"/> returns the expected string representation.
+    /// </summary>
+    [Fact]
+    public void ToString_ReturnsExpectedString()
+    {
+        // Arrange
+        const string expected = $"Alice 10{ContestResultParser.ContestantResultSeparator} Bob 8";
+        var contestResult = new ContestResult
+        {
+            Contestant1Name = "Alice",
+            Contestant1Score = 10,
+            Contestant2Name = "Bob",
+            Contestant2Score = 8,
+        };
+
+        // Act
+        var actual = contestResult.ToString();
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+}

--- a/test/Rankings.UnitTests/ProgramTests.cs
+++ b/test/Rankings.UnitTests/ProgramTests.cs
@@ -9,7 +9,7 @@ namespace Rankings.UnitTests;
 public class ProgramTests
 {
     /// <summary>
-    ///     Tests that the <see cref="Program.Main"/> method configures the root command with the expected options.
+    ///     Tests that <see cref="Program.Main"/> configures the root command with the expected options.
     /// </summary>
     [Fact]
     public void Main_ConfiguresRootCommandWithExpectedOptions()
@@ -30,7 +30,7 @@ public class ProgramTests
     }
     
     /// <summary>
-    ///     Tests that the <see cref="Program.Main"/> method configures the root command with the expected subcommands.
+    ///     Tests that <see cref="Program.Main"/> configures the root command with the expected subcommands.
     /// </summary>
     [Fact]
     public void Main_ConfiguresRootCommandWithExpectedSubcommands()
@@ -51,7 +51,7 @@ public class ProgramTests
     }
     
     /// <summary>
-    ///     Tests that the <see cref="Program.Main"/> method displays help when called with the "--help" argument.
+    ///     Tests that <see cref="Program.Main"/> displays help when called with the "--help" argument.
     /// </summary>
     /// <param name="arg">The help argument to test.</param>
     [Theory]
@@ -74,7 +74,7 @@ public class ProgramTests
     }
     
     /// <summary>
-    ///     Tests that the <see cref="Program.Main"/> method displays an error message when called with an invalid
+    ///     Tests that <see cref="Program.Main"/> displays an error message when called with an invalid
     ///     argument.
     /// </summary>
     [Fact]
@@ -95,7 +95,7 @@ public class ProgramTests
     }
     
     /// <summary>
-    ///     Tests that the <see cref="Program.Main"/> method does not throw an exception when called with no arguments.
+    ///     Tests that <see cref="Program.Main"/> does not throw an exception when called with no arguments.
     /// </summary>
     [Fact]
     public void Main_WithNoArguments_DoesNotThrow()

--- a/test/Rankings.UnitTests/Services/ContestResultsProcessorTests.cs
+++ b/test/Rankings.UnitTests/Services/ContestResultsProcessorTests.cs
@@ -1,0 +1,118 @@
+﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
+// Published under the MIT License.
+
+using Microsoft.Extensions.Options;
+using Moq;
+using Rankings.Parsers;
+using Rankings.Services;
+using Rankings.Storage;
+
+namespace Rankings.UnitTests.Services;
+
+/// <summary>
+///     Unit tests for the <see cref="ContestResultsProcessor"/> class.
+/// </summary>
+public class ContestResultsProcessorTests
+{
+    /// <summary>
+    ///     Tests that the constructor does not throw when provided with valid parameters.
+    /// </summary>
+    [Fact]
+    public void Ctor_WithValidParameters_DoesNotThrow()
+    {
+        // Arrange
+        var options = Options.Create(new ContestResultsProcessorOptions { FilePath = "test.json" });
+        var storageFactoryMock = new Mock<IStorageFactory>();
+
+        // Act
+        var exception = Record.Exception(() => new ContestResultsProcessor(options, storageFactoryMock.Object));
+        
+        // Assert
+        Assert.Null(exception);
+    }
+    
+    /// <summary>
+    ///     Tests that <see cref="ContestResultsProcessor.Process"/> throws an <see cref="InvalidOperationException"/>
+    ///     when provided with invalid contest results, and that the exception message matches the expected message
+    /// </summary>
+    /// <param name="input">The input string to validate.</param>
+    /// <param name="expected">The expected error message.</param>
+    [Theory]
+    [InlineData(
+        $"1{ContestResultParser.ContestantResultSeparator}2{ContestResultParser.ContestantResultSeparator}3",
+        $"A result can only contain one {ContestResultParser.ContestantResultSeparator} symbol.")]
+    [InlineData(
+        "12345",
+        $"A result must be separated into two parts by the {ContestResultParser.ContestantResultSeparator} symbol; one part for each contestant's name and score.")]
+    [InlineData(
+        $"{ContestResultParser.ContestantResultSeparator} Bob 20",
+        "A result must include the results for both contestants. Cannot find a result for contestant 1.")]
+    [InlineData(
+        $"Alice 10{ContestResultParser.ContestantResultSeparator}",
+        "A result must include the results for both contestants. Cannot find a result for contestant 2.")]
+    [InlineData(
+        $"10{ContestResultParser.ContestantResultSeparator} Bob 20",
+        "A result must include names for both contestants. Cannot find a name for contestant 1.")]
+    [InlineData(
+        $"Alice{ContestResultParser.ContestantResultSeparator} Bob 20",
+        "A result must include scores for both contestants. Cannot find a score for contestant 1.")]
+    [InlineData(
+        $"Alice 10{ContestResultParser.ContestantResultSeparator}20",
+        "A result must include names for both contestants. Cannot find a name for contestant 2.")]
+    [InlineData(
+        $"Alice 10{ContestResultParser.ContestantResultSeparator} Bob",
+        "A result must include scores for both contestants. Cannot find a score for contestant 2.")]
+    public void Process_WithInvalidContestResults_ThrowsInvalidOperationException(string input, string expected)
+    {
+        // Arrange
+        var options = Options.Create(new ContestResultsProcessorOptions { FilePath = "test.json" });
+        var storageFactoryMock = new Mock<IStorageFactory>();
+        var processor = new ContestResultsProcessor(options, storageFactoryMock.Object);
+        using var sw = new StringWriter();
+        Console.SetError(sw);
+        
+        // Act
+        var exception = Record.Exception(() => processor.Process([input]));
+        
+        // Assert
+        Assert.NotNull(exception);
+        Assert.IsType<InvalidOperationException>(exception);
+        Assert.Contains("Error in contestant result 1: ", sw.ToString());
+        Assert.Equal(expected, exception.Message);
+        storageFactoryMock.Verify(m => m.CreateFileStore(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void Process_WithValidContestResults_StoresResults()
+    {
+        // Arrange
+        var options = Options.Create(new ContestResultsProcessorOptions { FilePath = "test.json" });
+        var storageFactoryMock = new Mock<IStorageFactory>();
+        var fileStoreMock = new Mock<IStore>();
+        var processor = new ContestResultsProcessor(options, storageFactoryMock.Object);
+
+        storageFactoryMock
+            .Setup(m => m.CreateFileStore(It.IsAny<string>()))
+            .Returns(fileStoreMock.Object);
+        
+        fileStoreMock.Setup(m => m.IsInitialized).Returns(false);
+        fileStoreMock.Setup(m => m.Initialize());
+        fileStoreMock.Setup(m => m.AppendAllLines(It.IsAny<string[]>()));
+        
+        var contestResults = new[]
+        {
+            $"Alice 10{ContestResultParser.ContestantResultSeparator} Bob 20",
+            $"Charlie 15{ContestResultParser.ContestantResultSeparator} Dana 15"
+        };
+        
+        // Act
+        var exception = Record.Exception(() => processor.Process(contestResults));
+        
+        // Assert
+        Assert.Null(exception);
+        storageFactoryMock.Verify(m => m.CreateFileStore(options.Value.FilePath), Times.Once);
+        fileStoreMock.Verify(m => m.IsInitialized, Times.Once);
+        fileStoreMock.Verify(m => m.Initialize(), Times.Once);
+        fileStoreMock.Verify(m => m.AppendAllLines(It.IsAny<string[]>()), Times.Once);
+    }
+}

--- a/test/Rankings.UnitTests/Validators/FileValidatorTests.cs
+++ b/test/Rankings.UnitTests/Validators/FileValidatorTests.cs
@@ -21,12 +21,12 @@ public class FileValidatorTests
     /// <param name="expected">The expected error message.</param>
     [Theory]
     [InlineData("append-file --file", "Required argument missing for option: '--file'.")]
-    [InlineData("append-file --file \"invalid-filename-*.txt\"",
+    [InlineData("append-file --file \"invalid-file-name-*.txt\"",
         "The file name contains invalid characters and is invalid.")]
-    [InlineData($"append-file --file \"/\n/filename.txt\"",
+    [InlineData($"append-file --file \"/\n/file-name.txt\"",
         "The directory (folder) name contains invalid characters and is invalid.")]
-    [InlineData("append-file --file \"\"", "The file name is missing or empty and is invalid.")]
-    [InlineData("append-file --file \"./\"", "The file name is missing or empty and is invalid.")]
+    [InlineData("append-file --file \"\"", "The file name is missing or empty.")]
+    [InlineData("append-file --file \"./\"", "The file name is missing or empty.")]
     public void Validate_WithError_AddsError(string input, string expected)
     {
         // Arrange
@@ -53,7 +53,7 @@ public class FileValidatorTests
         var rootCommand = new RootCommand();
         var serviceProviderMockObject = Mock.Of<IServiceProvider>();
         rootCommand.AddAppendFileSubcommand(serviceProviderMockObject);
-        const string input = "append-file --file \"valid-filename.txt\"";
+        const string input = "append-file --file \"valid-file-name.txt\"";
 
         // Act
         var parseResult = rootCommand.Parse(input);

--- a/test/Rankings.UnitTests/Validators/ResultValidatorTests.cs
+++ b/test/Rankings.UnitTests/Validators/ResultValidatorTests.cs
@@ -32,28 +32,28 @@ public class ResultValidatorTests
         "append-result --result \"1\r\n2\"",
         "A result must not contain any line breaks, it must be a single line.")]
     [InlineData(
-        $"append-result --result \"1{ResultParser.ContestantResultSeparator}2{ResultParser.ContestantResultSeparator}3\"",
-        $"A result can only contain one {ResultParser.ContestantResultSeparator} symbol.")]
+        $"append-result --result \"1{ContestResultParser.ContestantResultSeparator}2{ContestResultParser.ContestantResultSeparator}3\"",
+        $"A result can only contain one {ContestResultParser.ContestantResultSeparator} symbol.")]
     [InlineData(
         "append-result --result \"12345\"",
-        $"A result must be separated into two parts by the {ResultParser.ContestantResultSeparator} symbol; one part for each contestant's name and score.")]
+        $"A result must be separated into two parts by the {ContestResultParser.ContestantResultSeparator} symbol; one part for each contestant's name and score.")]
     [InlineData(
-        $"append-result --result \"{ResultParser.ContestantResultSeparator} Bob 20\"",
+        $"append-result --result \"{ContestResultParser.ContestantResultSeparator} Bob 20\"",
         "A result must include the results for both contestants. Cannot find a result for contestant 1.")]
     [InlineData(
-        $"append-result --result \"Alice 10{ResultParser.ContestantResultSeparator}\"",
+        $"append-result --result \"Alice 10{ContestResultParser.ContestantResultSeparator}\"",
         "A result must include the results for both contestants. Cannot find a result for contestant 2.")]
     [InlineData(
-        $"append-result --result \"10{ResultParser.ContestantResultSeparator} Bob 20\"",
+        $"append-result --result \"10{ContestResultParser.ContestantResultSeparator} Bob 20\"",
         "A result must include names for both contestants. Cannot find a name for contestant 1.")]
     [InlineData(
-        $"append-result --result \"Alice{ResultParser.ContestantResultSeparator} Bob 20\"",
+        $"append-result --result \"Alice{ContestResultParser.ContestantResultSeparator} Bob 20\"",
         "A result must include scores for both contestants. Cannot find a score for contestant 1.")]
     [InlineData(
-        $"append-result --result \"Alice 10{ResultParser.ContestantResultSeparator}20\"",
+        $"append-result --result \"Alice 10{ContestResultParser.ContestantResultSeparator}20\"",
         "A result must include names for both contestants. Cannot find a name for contestant 2.")]
     [InlineData(
-        $"append-result --result \"Alice 10{ResultParser.ContestantResultSeparator} Bob\"",
+        $"append-result --result \"Alice 10{ContestResultParser.ContestantResultSeparator} Bob\"",
         "A result must include scores for both contestants. Cannot find a score for contestant 2.")]
     public void Validate_WithError_AddsError(string input, string expected)
     {
@@ -81,7 +81,7 @@ public class ResultValidatorTests
         var rootCommand = new RootCommand();
         var serviceProviderMockObject = Mock.Of<IServiceProvider>();
         rootCommand.AddAppendResultSubcommand(serviceProviderMockObject);
-        const string input = $"append-result --result \"Alice 10{ResultParser.ContestantResultSeparator} Bob 20\"";
+        const string input = $"append-result --result \"Alice 10{ContestResultParser.ContestantResultSeparator} Bob 20\"";
 
         // Act
         var parseResult = rootCommand.Parse(input);


### PR DESCRIPTION
This pull request introduces a new `ContestResult` domain model and refactors the parsing logic to use a new `ContestResultParser` class. It also improves dependency injection and error handling for command handlers, and adds configuration for the contest results processor service. These changes enhance the codebase's maintainability, validation, and extensibility.

**Domain Model and Parsing Refactor:**

* Added new `ContestResult` class to represent a contest result, encapsulating contestant names and scores.
* Renamed and refactored `ResultParser` to `ContestResultParser`, improving validation, error messaging, and exposing a method to return a strongly-typed `ContestResult`.

**Dependency Injection and Configuration:**

* Registered `IContestResultsProcessor` and configured its options in the DI container in `Program.cs`, enabling easier service management and configuration.
* Added missing DI package reference (`Microsoft.Extensions.Options`) to the project file to support options configuration.

**Command Handler Improvements:**

* Refactored command handlers in `RankingsRootCommandExtensions.cs` to resolve dependencies via DI, improve error handling, and clarify handler definition location for maintainability.