### PR TITLE
feat: Add clear-contest-results subcommand and implement clearing fun…

### DIFF
--- a/src/Rankings/CommandLineSubcommands.cs
+++ b/src/Rankings/CommandLineSubcommands.cs
@@ -9,12 +9,17 @@ namespace Rankings;
 public abstract record CommandLineSubcommands
 {
     /// <summary>
-    ///     Represents the append-file subcommand used to append contestant results from a file.
+    ///     Represents the append-file subcommand used to append contest results from a file.
     /// </summary>
     public static string AppendFile { get; } = "append-file";
     
     /// <summary>
-    ///     Represents the append-result subcommand used to append a contestant result from the command line.
+    ///     Represents the append-result subcommand used to append a contest result from the command line.
     /// </summary>
     public static string AppendResult { get; } = "append-result";
+    
+    /// <summary>
+    ///     Represents the clear-contest-results subcommand used to clear all contest results.
+    /// </summary>
+    public static string ClearContestResults { get; } = "clear-contest-results";
 }

--- a/src/Rankings/Extensions/RankingsRootCommandExtensions.cs
+++ b/src/Rankings/Extensions/RankingsRootCommandExtensions.cs
@@ -145,4 +145,47 @@ public static class RankingsRootCommandExtensions
         
         return rootCommand;
     }
+    
+    /// <summary>
+    ///     Adds the clear contest results subcommand to the root command.
+    /// </summary>
+    /// <param name="rootCommand">The root command receiving the subcommand.</param>
+    /// <param name="serviceProvider">The service provider used to support dependency injection.</param>
+    /// <returns>The root command with the configured subcommand added.</returns>
+    public static RootCommand AddClearContestResultsSubcommand(this RootCommand rootCommand, IServiceProvider serviceProvider)
+    {
+        var clearContestResultsCommand = new Command(
+            CommandLineSubcommands.ClearContestResults,
+            Common.ClearContestResults_Subcommand_Description);
+        
+        /*
+         * The handler for a command is dependent on its options and arguments. As such, the cleanest way to define
+         * the handler is where the options and arguments are defined to avoid brittle abstractions.
+         */
+        clearContestResultsCommand.SetAction(_ =>
+        {
+            try
+            {
+                // Resolve dependencies.
+                var processor = serviceProvider.GetService<IContestResultsProcessor>()
+                                ?? throw new InvalidOperationException(Common.ContestResultsProcessor_NotRegistered);
+                
+                // Clear all contest results that were previously processed and stored.
+                processor.ClearContestResults();
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine(e.Message);
+                Environment.ExitCode = 1;
+                return Environment.ExitCode;
+            }
+
+            Environment.ExitCode = 0;
+            return Environment.ExitCode;
+        });
+        
+        rootCommand.Add(clearContestResultsCommand);
+        
+        return rootCommand;
+    }
 }

--- a/src/Rankings/Program.cs
+++ b/src/Rankings/Program.cs
@@ -40,6 +40,7 @@ public abstract class Program
         _rootCommand = new RootCommand(Common.RootCommand_Description);
         _rootCommand.AddAppendFileSubcommand(serviceProvider);
         _rootCommand.AddAppendResultSubcommand(serviceProvider);
+        _rootCommand.AddClearContestResultsSubcommand(serviceProvider);
         _rootCommand.SetAction(_ => 0);
         
         // Automatically handles unhandled exceptions thrown during parsing or invocation.

--- a/src/Rankings/Resources/Common.Designer.cs
+++ b/src/Rankings/Resources/Common.Designer.cs
@@ -87,6 +87,15 @@ namespace Rankings.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Clears contest results from the contest results store..
+        /// </summary>
+        internal static string ClearContestResults_Subcommand_Description {
+            get {
+                return ResourceManager.GetString("ClearContestResults_Subcommand_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The file specified cannot be accessed. The file name and path may be incorrect, the file may not be accessible, or the file may not exist..
         /// </summary>
         internal static string CommonAppendFile_Subcommand_FileNotAccessible {
@@ -155,6 +164,15 @@ namespace Rankings.Resources {
         internal static string ContestResultParser_Validation_NoContestantScore {
             get {
                 return ResourceManager.GetString("ContestResultParser_Validation_NoContestantScore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Success: The contest results store has been cleared..
+        /// </summary>
+        internal static string ContestResultsProcessor_Clear_Success {
+            get {
+                return ResourceManager.GetString("ContestResultsProcessor_Clear_Success", resourceCulture);
             }
         }
         

--- a/src/Rankings/Resources/Common.resx
+++ b/src/Rankings/Resources/Common.resx
@@ -84,4 +84,10 @@
     <data name="ContestResultsProcessor_Processing_Success" xml:space="preserve">
         <value>Success: Added {0} contest result(s) to the contest results store. Rerun the command without any arguments to see the rankings latest table.</value>
     </data>
+    <data name="ClearContestResults_Subcommand_Description" xml:space="preserve">
+        <value>Clears contest results from the contest results store.</value>
+    </data>
+    <data name="ContestResultsProcessor_Clear_Success" xml:space="preserve">
+        <value>Success: The contest results store has been cleared.</value>
+    </data>
 </root>

--- a/src/Rankings/Services/ContestResultsProcessor.cs
+++ b/src/Rankings/Services/ContestResultsProcessor.cs
@@ -32,7 +32,17 @@ public class ContestResultsProcessor : IContestResultsProcessor
         _options = options;
         _storageFactory = storageFactory;
     }
-    
+
+    /// <inheritdoc />
+    public void ClearContestResults()
+    {
+        var store = _storageFactory.CreateFileStore(_options.Value.FilePath);
+        
+        if (store.IsInitialized) store.Reset();
+        
+        Console.Write(Common.ContestResultsProcessor_Clear_Success);
+    }
+
     /// <inheritdoc />
     /// <exception cref="InvalidOperationException">Thrown if any of the results are invalid.</exception>
     public void Process(string[] contestResults)

--- a/src/Rankings/Services/IContestResultsProcessor.cs
+++ b/src/Rankings/Services/IContestResultsProcessor.cs
@@ -9,6 +9,11 @@ namespace Rankings.Services;
 public interface IContestResultsProcessor
 {
     /// <summary>
+    ///     Clears all previously processed and stored contest results.
+    /// </summary>
+    public void ClearContestResults();
+    
+    /// <summary>
     ///     Processes the provided contest results.
     /// </summary>
     /// <param name="contestResults">The contest results to process.</param>

--- a/src/Rankings/Storage/FileStore.cs
+++ b/src/Rankings/Storage/FileStore.cs
@@ -48,4 +48,14 @@ public class FileStore : FileReadOnlyStore, IStore
             // Just create, then dispose of the file handle.
         }
     }
+    
+    /// <inheritdoc />
+    [ExcludeFromCodeCoverage(Justification = "File IO is an OS concern.")]
+    public void Reset()
+    {
+        // Any exception thrown bubbles up to be handled by the caller.
+        if (FileInfo.Exists) return;
+        
+        FileInfo.Delete();
+    }
 }

--- a/src/Rankings/Storage/FileStore.cs
+++ b/src/Rankings/Storage/FileStore.cs
@@ -54,7 +54,7 @@ public class FileStore : FileReadOnlyStore, IStore
     public void Reset()
     {
         // Any exception thrown bubbles up to be handled by the caller.
-        if (FileInfo.Exists) return;
+        if (!FileInfo.Exists) return;
         
         FileInfo.Delete();
     }

--- a/src/Rankings/Storage/IStore.cs
+++ b/src/Rankings/Storage/IStore.cs
@@ -17,4 +17,9 @@ public interface IStore : IReadOnlyStore
     ///     Initializes the store, creating any backing resources if they do not already exist.
     /// </summary>
     public void Initialize();
+
+    /// <summary>
+    ///     Resets the store, clearing all data and returning it to an uninitialized state.
+    /// </summary>
+    public void Reset();
 }

--- a/test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs
+++ b/test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs
@@ -132,4 +132,53 @@ public class RankingsRootCommandExtensionsTests
         resultsProcessorMock
             .Verify(m => m.Process(It.IsAny<string[]>()), Times.Once);
     }
+    
+    /// <summary>
+    ///     Tests that <see cref="RankingsRootCommandExtensions.AddClearContestResultsSubcommand" /> correctly adds
+    ///     the result option to a root command.
+    /// </summary>
+    [Fact]
+    public void AddClearContestResultsSubcommand_AddsSubcommandToRootCommand()
+    {
+        // Arrange
+        var rootCommand = new RootCommand();
+        const string expectedSubcommandName = "clear-contest-results";
+        var serviceProviderMockObject = Mock.Of<IServiceProvider>();
+        
+        // Act
+        rootCommand.AddClearContestResultsSubcommand(serviceProviderMockObject);
+        var subcommand = rootCommand
+            .Subcommands.FirstOrDefault(o => o.Name == expectedSubcommandName);
+        
+        // Assert
+        Assert.NotNull(subcommand);
+        Assert.Equal(expectedSubcommandName, subcommand.Name);
+        Assert.NotNull(subcommand.Description);
+        Assert.NotEmpty(subcommand.Description);
+    }
+
+    [Fact]
+    public void AddClearContestResultsSubcommand_Handler_HandlesInvocation()
+    {
+        // Arrange
+        var rootCommand = new RootCommand();
+        
+        var resultsProcessorMock = new Mock<IContestResultsProcessor>();
+        
+        var serviceProviderMock = new Mock<IServiceProvider>();
+
+        rootCommand.AddClearContestResultsSubcommand(serviceProviderMock.Object);
+        
+        serviceProviderMock.Setup(m => m.GetService(typeof(IContestResultsProcessor)))
+            .Returns(resultsProcessorMock.Object);
+        
+        // Act
+        var parseResult = rootCommand.Parse("clear-contest-results");
+        parseResult.Invoke();
+        
+        // Assert
+        serviceProviderMock.Verify(m => m.GetService(typeof(IContestResultsProcessor)), Times.Once);
+        resultsProcessorMock
+            .Verify(m => m.ClearContestResults(), Times.Once);
+    }
 }

--- a/test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs
+++ b/test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs
@@ -157,6 +157,10 @@ public class RankingsRootCommandExtensionsTests
         Assert.NotEmpty(subcommand.Description);
     }
 
+    /// <summary>
+    ///     Tests that the handler defined in <see cref="RankingsRootCommandExtensions.AddClearContestResultsSubcommand" />
+    ///     handles invocation correctly.
+    /// </summary>
     [Fact]
     public void AddClearContestResultsSubcommand_Handler_HandlesInvocation()
     {

--- a/test/Rankings.UnitTests/ProgramTests.cs
+++ b/test/Rankings.UnitTests/ProgramTests.cs
@@ -39,7 +39,8 @@ public class ProgramTests
         var expectedSubcommands = new[]
         {
             "append-file",
-            "append-result"
+            "append-result",
+            "clear-contest-results"
         };
 
         // Act

--- a/test/Rankings.UnitTests/ProgramTests.cs
+++ b/test/Rankings.UnitTests/ProgramTests.cs
@@ -64,6 +64,7 @@ public class ProgramTests
         // Arrange
         const string expected = "Show help and usage information";
         using var sw = new StringWriter();
+        var originalOut = Console.Out;
         Console.SetOut(sw);
 
         // Act
@@ -72,6 +73,9 @@ public class ProgramTests
 
         // Assert
         Assert.Contains(expected, actual);
+        
+        // Cleanup
+        Console.SetOut(originalOut);
     }
     
     /// <summary>
@@ -85,6 +89,7 @@ public class ProgramTests
         const string expected = "Unrecognized command or argument '--invalid'.";
         const string invalidArg = "--invalid";
         using var sw = new StringWriter();
+        var originalError = Console.Error;
         Console.SetError(sw);
 
         // Act
@@ -93,19 +98,31 @@ public class ProgramTests
 
         // Assert
         Assert.Contains(expected, actual);
+        
+        // Cleanup
+        Console.SetError(originalError);
     }
     
     /// <summary>
-    ///     Tests that <see cref="Program.Main"/> does not throw an exception when called with no arguments.
+    ///     Tests that <see cref="Program.Main"/> succeeds when called with no arguments.
     /// </summary>
     [Fact]
-    public void Main_WithNoArguments_DoesNotThrow()
+    public void Main_WithNoArguments_Succeeds()
     {
         // Arrange
         var args = Array.Empty<string>();
+        using var sw = new StringWriter();
+        var originalError = Console.Error;
+        Console.SetError(sw);
 
-        // Act & Assert
-        var exception = Record.Exception(() => Program.Main(args));
-        Assert.Null(exception);
+        // Act
+        Program.Main(args);
+        var actual = sw.ToString();
+        
+        // Assert
+        Assert.Empty(actual);
+        
+        // Cleanup
+        Console.SetError(originalError);
     }
 }

--- a/test/Rankings.UnitTests/Services/ContestResultsProcessorTests.cs
+++ b/test/Rankings.UnitTests/Services/ContestResultsProcessorTests.cs
@@ -15,20 +15,20 @@ namespace Rankings.UnitTests.Services;
 public class ContestResultsProcessorTests
 {
     /// <summary>
-    ///     Tests that the constructor does not throw when provided with valid parameters.
+    ///     Tests that the constructor instantiates the object when provided with valid parameters.
     /// </summary>
     [Fact]
-    public void Ctor_WithValidParameters_DoesNotThrow()
+    public void Ctor_WithValidParameters_Instantiates()
     {
         // Arrange
         var options = Options.Create(new ContestResultsProcessorOptions { FilePath = "test.json" });
         var storageFactoryMock = new Mock<IStorageFactory>();
 
         // Act
-        var exception = Record.Exception(() => new ContestResultsProcessor(options, storageFactoryMock.Object));
+        var actual = new ContestResultsProcessor(options, storageFactoryMock.Object);
         
         // Assert
-        Assert.Null(exception);
+        Assert.NotNull(actual);
     }
 
     [Fact]
@@ -46,10 +46,9 @@ public class ContestResultsProcessorTests
         fileStoreMock.Setup(m => m.IsInitialized).Returns(true);
         
         // Act
-        var exception = Record.Exception(() => processor.ClearContestResults());
+        processor.ClearContestResults();
         
         // Assert
-        Assert.Null(exception);
         storageFactoryMock.Verify(m => m.CreateFileStore(options.Value.FilePath), Times.Once);
         fileStoreMock.Verify(m => m.IsInitialized, Times.Once);
         fileStoreMock.Verify(m => m.Reset(), Times.Once);
@@ -93,6 +92,7 @@ public class ContestResultsProcessorTests
         var storageFactoryMock = new Mock<IStorageFactory>();
         var processor = new ContestResultsProcessor(options, storageFactoryMock.Object);
         using var sw = new StringWriter();
+        var originalError = Console.Error;
         Console.SetError(sw);
         
         // Act
@@ -104,6 +104,9 @@ public class ContestResultsProcessorTests
         Assert.Contains("Error in contestant result 1: ", sw.ToString());
         Assert.Equal(expected, exception.Message);
         storageFactoryMock.Verify(m => m.CreateFileStore(It.IsAny<string>()), Times.Never);
+        
+        // Cleanup
+        Console.SetError(originalError);
     }
 
     /// <summary>
@@ -132,10 +135,9 @@ public class ContestResultsProcessorTests
         };
         
         // Act
-        var exception = Record.Exception(() => processor.Process(contestResults));
+        processor.Process(contestResults);
         
         // Assert
-        Assert.Null(exception);
         storageFactoryMock.Verify(m => m.CreateFileStore(options.Value.FilePath), Times.Once);
         fileStoreMock.Verify(m => m.IsInitialized, Times.Once);
         fileStoreMock.Verify(m => m.Initialize(), Times.Once);

--- a/test/Rankings.UnitTests/Storage/FileReadOnlyStoreTests.cs
+++ b/test/Rankings.UnitTests/Storage/FileReadOnlyStoreTests.cs
@@ -47,18 +47,18 @@ public class FileReadOnlyStoreTests
     }
     
     /// <summary>
-    ///     Tests that the constructor does not throw when the input is a valid file name.
+    ///     Tests that the constructor instantiates the object when the input is a valid file name.
     /// </summary>
     [Fact]
-    public void Ctor_WithValidFullName_DoesNotThrow()
+    public void Ctor_WithValidFullName_Instantiates()
     {
         // Arrange
         const string fullName = "validFileName.txt";
         
         // Act
-        var exception = Record.Exception(() => new FileReadOnlyStore(fullName));
+        var actual = new FileReadOnlyStore(fullName);
         
         // Assert
-        Assert.Null(exception);
+        Assert.NotNull(actual);
     }
 }

--- a/test/Rankings.UnitTests/Storage/FileStoreTests.cs
+++ b/test/Rankings.UnitTests/Storage/FileStoreTests.cs
@@ -47,18 +47,18 @@ public class FileStoreTests
     }
     
     /// <summary>
-    ///     Tests that the constructor does not throw when the input is a valid file name.
+    ///     Tests that the constructor instantiates the object when the input is a valid file name.
     /// </summary>
     [Fact]
-    public void Ctor_WithValidFullName_DoesNotThrow()
+    public void Ctor_WithValidFullName_Instantiates()
     {
         // Arrange
         const string fullName = "validFileName.txt";
         
         // Act
-        var exception = Record.Exception(() => new FileStore(fullName));
+        var actual = new FileStore(fullName);
         
         // Assert
-        Assert.Null(exception);
+        Assert.NotNull(actual);
     }
 }


### PR DESCRIPTION
This pull request introduces a new subcommand to the rankings CLI that allows users to clear all contest results from the results store. The implementation includes updates to the command definitions, dependency injection, the results processor service, and associated tests to ensure correctness. Additionally, resource files have been updated to provide appropriate descriptions and success messages for the new functionality.

**New CLI functionality:**

* Added a `clear-contest-results` subcommand to the CLI, allowing users to clear all contest results from the store (`CommandLineSubcommands`, `RankingsRootCommandExtensions.cs`, `Program.cs`).

**Service and storage changes:**

* Implemented the `ClearContestResults` method in `ContestResultsProcessor` and its interface, which uses the `Reset` method on the results store to clear all data (`IContestResultsProcessor.cs`, `ContestResultsProcessor.cs`).

**Localization and resource updates:**

* Added localized descriptions and success messages for the new subcommand in `Common.resx` and `Common.Designer.cs` (`Common.resx`, `Common.Designer.cs`).

**Testing improvements:**

* Added and updated unit tests to verify the new subcommand is registered, its handler is invoked correctly, and the results store is reset as expected (`RankingsRootCommandExtensionsTests.cs`, `ProgramTests.cs`, `ContestResultsProcessorTests.cs`).

**Documentation and naming consistency:**

* Updated documentation comments for subcommands to use consistent terminology ("contest results" instead of "contestant results") (`CommandLineSubcommands`).