### PR TITLE
feat: Implement ranking table display and no data handling in Contest…

### DIFF
--- a/src/Rankings/Extensions/RankingsRootCommandExtensions.cs
+++ b/src/Rankings/Extensions/RankingsRootCommandExtensions.cs
@@ -187,4 +187,41 @@ public static class RankingsRootCommandExtensions
 
         return rootCommand;
     }
+
+    /// <summary>
+    ///     Sets the action for the root command.
+    /// </summary>
+    /// <param name="rootCommand">The root command being set.</param>
+    /// <param name="serviceProvider">The service provider used to support dependency injection.</param>
+    /// <returns>The root command with the configured action.</returns>
+    public static RootCommand SetRootCommandAction(this RootCommand rootCommand, IServiceProvider serviceProvider)
+    {
+        /*
+         * The handler for a command is dependent on its options and arguments. As such, the cleanest way to define
+         * the handler is where the options and arguments are defined to avoid brittle abstractions.
+         */
+        rootCommand.SetAction(_ =>
+        {
+            try
+            {
+                // Resolve dependencies.
+                var processor = serviceProvider.GetService<IContestResultsProcessor>()
+                                ?? throw new InvalidOperationException(Common.ContestResultsProcessor_NotRegistered);
+
+                // Display the ranking table.
+                processor.DisplayRankingTable();
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine(e.Message);
+                Environment.ExitCode = 1;
+                return Environment.ExitCode;
+            }
+
+            Environment.ExitCode = 0;
+            return Environment.ExitCode;
+        });
+
+        return rootCommand;
+    }
 }

--- a/src/Rankings/Parsers/ContestResultParser.cs
+++ b/src/Rankings/Parsers/ContestResultParser.cs
@@ -215,13 +215,13 @@ public class ContestResultParser
     ///     Indicates whether the input is valid.
     /// </summary>
     public bool IsValid => !(HasMultipleContestantResultSeparators
-                           || IsMissingContestantResultSeparator
-                           || HasNoContestant1Result
-                           || HasNoContestant2Result
-                           || HasNoContestant1Name
-                           || HasNoContestant1Score
-                           || HasNoContestant2Name
-                           || HasNoContestant2Score);
+                             || IsMissingContestantResultSeparator
+                             || HasNoContestant1Result
+                             || HasNoContestant2Result
+                             || HasNoContestant1Name
+                             || HasNoContestant1Score
+                             || HasNoContestant2Name
+                             || HasNoContestant2Score);
 
     /// <summary>
     ///     Gets the parsed <see cref="ContestResult" /> if the input is valid.

--- a/src/Rankings/Program.cs
+++ b/src/Rankings/Program.cs
@@ -51,7 +51,7 @@ public abstract class Program
         _rootCommand.AddAppendFileSubcommand(serviceProvider);
         _rootCommand.AddAppendResultSubcommand(serviceProvider);
         _rootCommand.AddClearContestResultsSubcommand(serviceProvider);
-        _rootCommand.SetAction(_ => 0);
+        _rootCommand.SetRootCommandAction(serviceProvider);
 
         // Automatically handles unhandled exceptions thrown during parsing or invocation.
         _rootCommand.Parse(args).Invoke();

--- a/src/Rankings/Resources/Common.Designer.cs
+++ b/src/Rankings/Resources/Common.Designer.cs
@@ -177,6 +177,24 @@ namespace Rankings.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot display the ranking table because no results exist in the contest results store. Please add results, then retry..
+        /// </summary>
+        internal static string ContestResultsProcessor_Display_NoData {
+            get {
+                return ResourceManager.GetString("ContestResultsProcessor_Display_NoData", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}. {1}, {2} {3}.
+        /// </summary>
+        internal static string ContestResultsProcessor_DisplayRankingTable_Row {
+            get {
+                return ResourceManager.GetString("ContestResultsProcessor_DisplayRankingTable_Row", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fatal error: The contest results processor is not registered..
         /// </summary>
         internal static string ContestResultsProcessor_NotRegistered {
@@ -191,6 +209,33 @@ namespace Rankings.Resources {
         internal static string ContestResultsProcessor_Processing_Success {
             get {
                 return ResourceManager.GetString("ContestResultsProcessor_Processing_Success", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The current ranking is:.
+        /// </summary>
+        internal static string ContestResultsProcessor_RankingDisplay_Header {
+            get {
+                return ResourceManager.GetString("ContestResultsProcessor_RankingDisplay_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to pts.
+        /// </summary>
+        internal static string ContestResultsProcessor_RankingDisplay_PointPlural {
+            get {
+                return ResourceManager.GetString("ContestResultsProcessor_RankingDisplay_PointPlural", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to pt.
+        /// </summary>
+        internal static string ContestResultsProcessor_RankingDisplay_PointSingular {
+            get {
+                return ResourceManager.GetString("ContestResultsProcessor_RankingDisplay_PointSingular", resourceCulture);
             }
         }
         

--- a/src/Rankings/Resources/Common.resx
+++ b/src/Rankings/Resources/Common.resx
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <root>
-    <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root"
+    <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata"
+                id="root"
                 xmlns="">
         <xsd:element name="root" msdata:IsDataSet="true">
 
@@ -94,5 +95,20 @@
     </data>
     <data name="ContestResultsProcessor_Clear_Success" xml:space="preserve">
         <value>Success: The contest results store has been cleared.</value>
+    </data>
+    <data name="ContestResultsProcessor_Display_NoData" xml:space="preserve">
+        <value>Cannot display the ranking table because no results exist in the contest results store. Please add results, then retry.</value>
+    </data>
+    <data name="ContestResultsProcessor_RankingDisplay_Header" xml:space="preserve">
+        <value>The current ranking is:</value>
+    </data>
+    <data name="ContestResultsProcessor_RankingDisplay_PointSingular" xml:space="preserve">
+        <value>pt</value>
+    </data>
+    <data name="ContestResultsProcessor_RankingDisplay_PointPlural" xml:space="preserve">
+        <value>pts</value>
+    </data>
+    <data name="ContestResultsProcessor_DisplayRankingTable_Row" xml:space="preserve">
+        <value>{0}. {1}, {2} {3}</value>
     </data>
 </root>

--- a/src/Rankings/Services/ContestResultsProcessor.cs
+++ b/src/Rankings/Services/ContestResultsProcessor.cs
@@ -163,13 +163,13 @@ public class ContestResultsProcessor : IContestResultsProcessor
                 ? pointsForWin
                 : pointsForLoss;
             if (result.Contestant1Score == result.Contestant2Score)
-                contestant1Points += pointsForDraw;
+                contestant1Points = pointsForDraw;
 
             var contestant2Points = result.Contestant2Score > result.Contestant1Score
                 ? pointsForWin
                 : pointsForLoss;
             if (result.Contestant1Score == result.Contestant2Score)
-                contestant2Points += pointsForDraw;
+                contestant2Points = pointsForDraw;
 
             if (!rankings.ContainsKey(result.Contestant1Name))
                 rankings.Add(result.Contestant1Name, contestant1Points);

--- a/src/Rankings/Services/ContestResultsProcessor.cs
+++ b/src/Rankings/Services/ContestResultsProcessor.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright © 2025 Seb Garrioch. All rights reserved.
 // Published under the MIT License.
 
+using System.Collections;
+using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
 using Rankings.Parsers;
@@ -44,6 +46,65 @@ public class ContestResultsProcessor : IContestResultsProcessor
     }
 
     /// <inheritdoc />
+    public void DisplayRankingTable()
+    {
+        var readOnlyStore = _storageFactory.CreateFileReadOnlyStore(_options.Value.FilePath);
+        if (!readOnlyStore.IsInitialized || readOnlyStore.IsEmpty)
+        {
+            Console.Write(Common.ContestResultsProcessor_Display_NoData);
+            return;
+        }
+
+        // Get the data, then deserialize.
+        var allLines = readOnlyStore.ReadAllLines();
+        var allResults = new List<ContestResult>();
+        foreach (var line in allLines)
+        {
+            var result = JsonSerializer.Deserialize<ContestResult>(line)!;
+            // The result should never be null due to validation during processing.
+            Debug.Assert(result != null);
+            allResults.Add(result);
+        }
+
+        var rankings = CalculateRankings(allResults);
+
+        // Sort the rankings by points (descending) and then by name (ascending).
+        var sortedRankings = rankings.Cast<DictionaryEntry>()
+            .OrderByDescending(entry => (ushort)entry.Value!)
+            .ThenBy(entry => (string)entry.Key)
+            .ToList();
+
+        // Display the rankings.
+        Console.WriteLine(Common.ContestResultsProcessor_RankingDisplay_Header);
+        var rank = 0;
+        var rankOffset = 0;
+        var previousPoints = -1;
+        foreach (var entry in sortedRankings)
+        {
+            var contestantName = (string)entry.Key;
+            var points = (ushort)entry.Value!;
+            var pointLabel = points == 1
+                ? Common.ContestResultsProcessor_RankingDisplay_PointSingular
+                : Common.ContestResultsProcessor_RankingDisplay_PointPlural;
+
+            if (previousPoints != points)
+            {
+                rank += 1 + rankOffset;
+                rankOffset = 0;
+            }
+            else
+            {
+                rankOffset++;
+            }
+
+            previousPoints = points;
+
+            Console.WriteLine(Common.ContestResultsProcessor_DisplayRankingTable_Row, rank, contestantName, points,
+                pointLabel);
+        }
+    }
+
+    /// <inheritdoc />
     /// <exception cref="InvalidOperationException">Thrown if any of the results are invalid.</exception>
     public void Process(string[] contestResults)
     {
@@ -79,5 +140,49 @@ public class ContestResultsProcessor : IContestResultsProcessor
         store.AppendAllLines(jsonLines);
 
         Console.Write(Common.ContestResultsProcessor_Processing_Success, parsedResults.Count);
+    }
+
+    /// <summary>
+    ///     Calculates the rankings for contestants based on the provided results.
+    /// </summary>
+    /// <param name="allResults">The list of all contest results.</param>
+    /// <returns>
+    ///     A hashtable where the keys are contestant names and the values are their total points.
+    /// </returns>
+    private static Hashtable CalculateRankings(List<ContestResult> allResults)
+    {
+        const ushort pointsForWin = 3;
+        const ushort pointsForDraw = 1;
+        const ushort pointsForLoss = 0;
+
+        var rankings = new Hashtable();
+
+        foreach (var result in allResults)
+        {
+            var contestant1Points = result.Contestant1Score > result.Contestant2Score
+                ? pointsForWin
+                : pointsForLoss;
+            if (result.Contestant1Score == result.Contestant2Score)
+                contestant1Points += pointsForDraw;
+
+            var contestant2Points = result.Contestant2Score > result.Contestant1Score
+                ? pointsForWin
+                : pointsForLoss;
+            if (result.Contestant1Score == result.Contestant2Score)
+                contestant2Points += pointsForDraw;
+
+            if (!rankings.ContainsKey(result.Contestant1Name))
+                rankings.Add(result.Contestant1Name, contestant1Points);
+            else
+                rankings[result.Contestant1Name] =
+                    (ushort)((ushort)rankings[result.Contestant1Name]! + contestant1Points);
+            if (!rankings.ContainsKey(result.Contestant2Name))
+                rankings.Add(result.Contestant2Name, contestant2Points);
+            else
+                rankings[result.Contestant2Name] =
+                    (ushort)((ushort)rankings[result.Contestant2Name]! + contestant2Points);
+        }
+
+        return rankings;
     }
 }

--- a/src/Rankings/Services/IContestResultsProcessor.cs
+++ b/src/Rankings/Services/IContestResultsProcessor.cs
@@ -14,6 +14,11 @@ public interface IContestResultsProcessor
     public void ClearContestResults();
 
     /// <summary>
+    ///     Displays the current ranking table based on the processed and stored contest results.
+    /// </summary>
+    public void DisplayRankingTable();
+
+    /// <summary>
     ///     Processes the provided contest results.
     /// </summary>
     /// <param name="contestResults">The contest results to process.</param>

--- a/src/Rankings/Storage/FileReadOnlyStore.cs
+++ b/src/Rankings/Storage/FileReadOnlyStore.cs
@@ -36,7 +36,7 @@ public class FileReadOnlyStore : IReadOnlyStore
 
     /// <inheritdoc />
     /// <remarks>
-    ///     Exceptions are swallowed and <c>false</c> is returned if any are thrown,
+    ///     Exceptions are swallowed and <c>true</c> is returned if any are thrown.
     /// </remarks>
     [ExcludeFromCodeCoverage(Justification = "File IO is an OS concern.")]
     public bool IsEmpty
@@ -56,7 +56,7 @@ public class FileReadOnlyStore : IReadOnlyStore
 
     /// <inheritdoc />
     /// <remarks>
-    ///     Exceptions are swallowed and <c>false</c> is returned if any are thrown,
+    ///     Exceptions are swallowed and <c>false</c> is returned if any are thrown.
     /// </remarks>
     [ExcludeFromCodeCoverage(Justification = "File IO is an OS concern.")]
     public bool IsInitialized

--- a/src/Rankings/Storage/FileReadOnlyStore.cs
+++ b/src/Rankings/Storage/FileReadOnlyStore.cs
@@ -39,6 +39,26 @@ public class FileReadOnlyStore : IReadOnlyStore
     ///     Exceptions are swallowed and <c>false</c> is returned if any are thrown,
     /// </remarks>
     [ExcludeFromCodeCoverage(Justification = "File IO is an OS concern.")]
+    public bool IsEmpty
+    {
+        get
+        {
+            try
+            {
+                return FileInfo is { Exists: true, Length: 0 };
+            }
+            catch (Exception)
+            {
+                return true;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    ///     Exceptions are swallowed and <c>false</c> is returned if any are thrown,
+    /// </remarks>
+    [ExcludeFromCodeCoverage(Justification = "File IO is an OS concern.")]
     public bool IsInitialized
     {
         get

--- a/src/Rankings/Storage/IReadOnlyStore.cs
+++ b/src/Rankings/Storage/IReadOnlyStore.cs
@@ -9,6 +9,14 @@ namespace Rankings.Storage;
 public interface IReadOnlyStore
 {
     /// <summary>
+    ///     Indicates whether the store is empty.
+    /// </summary>
+    /// <returns>
+    ///     <c>True</c> if the store is empty; otherwise, <c>false</c>.
+    /// </returns>
+    public bool IsEmpty { get; }
+
+    /// <summary>
     ///     Indicates whether the store has been initialized.
     /// </summary>
     /// <returns>

--- a/test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs
+++ b/test/Rankings.UnitTests/Extensions/RankingsRootCommandExtensionsTests.cs
@@ -185,4 +185,33 @@ public class RankingsRootCommandExtensionsTests
         resultsProcessorMock
             .Verify(m => m.ClearContestResults(), Times.Once);
     }
+
+    /// <summary>
+    ///     Tests that the handler defined in <see cref="RankingsRootCommandExtensions.SetRootCommandAction" />
+    ///     handles invocation correctly.
+    /// </summary>
+    [Fact]
+    public void SetRootCommandAction_Handler_HandlesInvocation()
+    {
+        // Arrange
+        var rootCommand = new RootCommand();
+
+        var resultsProcessorMock = new Mock<IContestResultsProcessor>();
+
+        var serviceProviderMock = new Mock<IServiceProvider>();
+
+        rootCommand.SetRootCommandAction(serviceProviderMock.Object);
+
+        serviceProviderMock.Setup(m => m.GetService(typeof(IContestResultsProcessor)))
+            .Returns(resultsProcessorMock.Object);
+
+        // Act
+        var parseResult = rootCommand.Parse(string.Empty);
+        parseResult.Invoke();
+
+        // Assert
+        serviceProviderMock.Verify(m => m.GetService(typeof(IContestResultsProcessor)), Times.Once);
+        resultsProcessorMock
+            .Verify(m => m.DisplayRankingTable(), Times.Once);
+    }
 }

--- a/test/Rankings.UnitTests/Services/ContestResultsProcessorTests.cs
+++ b/test/Rankings.UnitTests/Services/ContestResultsProcessorTests.cs
@@ -58,6 +58,10 @@ public class ContestResultsProcessorTests
         fileStoreMock.Verify(m => m.Reset(), Times.Once);
     }
 
+    /// <summary>
+    ///     Tests that <see cref="ContestResultsProcessor.DisplayRankingTable" /> prints the ranking table when
+    ///     there are results in the store.
+    /// </summary>
     [Fact]
     public void DisplayRankingTable_WithData_PrintsRankingTable()
     {

--- a/test/Rankings.UnitTests/Services/ContestResultsProcessorTests.cs
+++ b/test/Rankings.UnitTests/Services/ContestResultsProcessorTests.cs
@@ -31,6 +31,10 @@ public class ContestResultsProcessorTests
         Assert.NotNull(actual);
     }
 
+    /// <summary>
+    ///     Tests that <see cref="ContestResultsProcessor.ClearContestResults" /> resets the store when it is
+    ///     initialized.
+    /// </summary>
     [Fact]
     public void ClearContestResults_ResetsStore()
     {
@@ -52,6 +56,96 @@ public class ContestResultsProcessorTests
         storageFactoryMock.Verify(m => m.CreateFileStore(options.Value.FilePath), Times.Once);
         fileStoreMock.Verify(m => m.IsInitialized, Times.Once);
         fileStoreMock.Verify(m => m.Reset(), Times.Once);
+    }
+
+    [Fact]
+    public void DisplayRankingTable_WithData_PrintsRankingTable()
+    {
+        // Arrange
+        var options = Options.Create(new ContestResultsProcessorOptions { FilePath = "test.json" });
+        var storageFactoryMock = new Mock<IStorageFactory>();
+        var fileReadOnlyStoreMock = new Mock<IReadOnlyStore>();
+        var processor = new ContestResultsProcessor(options, storageFactoryMock.Object);
+
+        storageFactoryMock
+            .Setup(m => m.CreateFileReadOnlyStore(It.IsAny<string>()))
+            .Returns(fileReadOnlyStoreMock.Object);
+        fileReadOnlyStoreMock.Setup(m => m.IsInitialized).Returns(true);
+        fileReadOnlyStoreMock.Setup(m => m.IsEmpty).Returns(false);
+        fileReadOnlyStoreMock.Setup(m => m.ReadAllLines()).Returns([
+            "{\"Contestant1Name\":\"alice FC\",\"Contestant1Score\":10,\"Contestant2Name\":\"FC Bob\",\"Contestant2Score\":20}",
+            "{\"Contestant1Name\":\"FC Bob\",\"Contestant1Score\":5,\"Contestant2Name\":\"Fred FC\",\"Contestant2Score\":3}",
+            "{\"Contestant1Name\":\"alice FC\",\"Contestant1Score\":2,\"Contestant2Name\":\"Fred FC\",\"Contestant2Score\":2}",
+            "{\"Contestant1Name\":\"alice FC\",\"Contestant1Score\":3,\"Contestant2Name\":\"Fred FC\",\"Contestant2Score\":3}",
+            "{\"Contestant1Name\":\"alice FC\",\"Contestant1Score\":4,\"Contestant2Name\":\"Fred FC\",\"Contestant2Score\":4}",
+            "{\"Contestant1Name\":\"alice FC\",\"Contestant1Score\":5,\"Contestant2Name\":\"Fred FC\",\"Contestant2Score\":5}",
+            "{\"Contestant1Name\":\"FC Dana\",\"Contestant1Score\":7,\"Contestant2Name\":\"FC Bob\",\"Contestant2Score\":5}",
+            "{\"Contestant1Name\":\"FC mike\",\"Contestant1Score\":1,\"Contestant2Name\":\"FC Ike\",\"Contestant2Score\":1}",
+            "{\"Contestant1Name\":\"FC Bob\",\"Contestant1Score\":3,\"Contestant2Name\":\"Rob FC\",\"Contestant2Score\":0}"
+        ]);
+
+        using var sw = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(sw);
+
+        // Act
+        processor.DisplayRankingTable();
+
+        // Assert
+        var output = sw.ToString();
+        Assert.Contains("The current ranking is:", output);
+        Assert.Contains("1. FC Bob, 9 pts", output);
+        Assert.Contains("2. alice FC, 4 pt", output);
+        Assert.Contains("2. Fred FC, 4 pt", output);
+        Assert.Contains("4. FC Dana, 3 pts", output);
+        Assert.Contains("5. FC Ike, 1 pt", output);
+        Assert.Contains("5. FC mike, 1 pt", output);
+        Assert.Contains("7. Rob FC, 0 pts", output);
+
+        storageFactoryMock.Verify(m => m.CreateFileReadOnlyStore(options.Value.FilePath), Times.Once);
+        fileReadOnlyStoreMock.Verify(m => m.IsInitialized, Times.Once);
+        fileReadOnlyStoreMock.Verify(m => m.IsEmpty, Times.Once);
+        fileReadOnlyStoreMock.Verify(m => m.ReadAllLines(), Times.Once);
+
+        // Cleanup
+        Console.SetOut(originalOut);
+    }
+
+    /// <summary>
+    ///     Tests that <see cref="ContestResultsProcessor.DisplayRankingTable" /> prints a no data message when
+    ///     there are no results in the store.
+    /// </summary>
+    [Fact]
+    public void DisplayRankingTable_WithNoData_PrintsNoDataMessage()
+    {
+        // Arrange
+        const string expectedMessage =
+            "Cannot display the ranking table because no results exist in the contest results store. Please add results, then retry.";
+        var options = Options.Create(new ContestResultsProcessorOptions { FilePath = "test.json" });
+        var storageFactoryMock = new Mock<IStorageFactory>();
+        var fileReadOnlyStoreMock = new Mock<IReadOnlyStore>();
+        var processor = new ContestResultsProcessor(options, storageFactoryMock.Object);
+
+        storageFactoryMock
+            .Setup(m => m.CreateFileReadOnlyStore(It.IsAny<string>()))
+            .Returns(fileReadOnlyStoreMock.Object);
+        fileReadOnlyStoreMock.Setup(m => m.IsInitialized).Returns(false);
+
+        using var sw = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(sw);
+
+        // Act
+        processor.DisplayRankingTable();
+
+        // Assert
+        Assert.Contains(expectedMessage, sw.ToString());
+
+        storageFactoryMock.Verify(m => m.CreateFileReadOnlyStore(options.Value.FilePath), Times.Once);
+        fileReadOnlyStoreMock.Verify(m => m.IsInitialized, Times.Once);
+
+        // Cleanup
+        Console.SetOut(originalOut);
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request adds a new feature to display the current contest rankings table, including its calculation, output formatting, and integration into the CLI root command. It also introduces new resource strings and tests to support and verify this functionality.

**Feature: Display Contest Rankings Table**

* Added a new `DisplayRankingTable` method to `ContestResultsProcessor` that calculates and prints the current rankings based on stored contest results, including rank, contestant name, and points, with proper formatting and tie handling.
* Updated `IContestResultsProcessor` interface to include the new `DisplayRankingTable` method.

**CLI Integration**

* Added `SetRootCommandAction` extension method to configure the root command to invoke `DisplayRankingTable` when executed, and updated `Program.cs` to use this new action.

**Localization and Output Formatting**

* Added new resource strings to `Common.resx` and `Common.Designer.cs` for ranking table headers, row formatting, and point labels (singular/plural).

**Storage Enhancements**

* Added `IsEmpty` property to `IReadOnlyStore` and implemented it in `FileReadOnlyStore` to support checking for empty contest results.

**Testing**

* Added unit tests for the new ranking table display functionality, including tests for output with data, output with no data, and root command handler invocation.